### PR TITLE
Add a hook to enqueue `nfd-wonder-blocks-utilities`

### DIFF
--- a/includes/CSSUtilities.php
+++ b/includes/CSSUtilities.php
@@ -10,6 +10,7 @@ class CSSUtilities {
 	public function __construct() {
 		\add_action( 'wp_enqueue_scripts', array( $this, 'enqueue' ) );
 		\add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue' ) );
+		\add_filter( 'enqueue_nfd_wonder_blocks_utilities', array( $this, 'enqueue' ) );
 	}
 
 	/**

--- a/includes/CSSUtilities.php
+++ b/includes/CSSUtilities.php
@@ -10,7 +10,7 @@ class CSSUtilities {
 	public function __construct() {
 		\add_action( 'wp_enqueue_scripts', array( $this, 'enqueue' ) );
 		\add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue' ) );
-		\add_filter( 'enqueue_nfd_wonder_blocks_utilities', array( $this, 'enqueue' ) );
+		\add_action( 'enqueue_nfd_wonder_blocks_utilities', array( $this, 'enqueue' ) );
 	}
 
 	/**


### PR DESCRIPTION
This hook gives consumers the flexibility to load `nfd-wonder-blocks-utilities` as needed via `do_action('enqueue_nfd_wonder_blocks_utilities')`.

Context:
When pulling blocks from the cloud patterns endpoint into the onboarding live previews, we avoid loading all the block editor assets (this prevents page lag when we have 6 previews in a page), we want to pull only what is necessary to render blocks in the preview. Hence, we prevent using the `enqueue_block_editor_assets` hook and wanted a way to load the CSS utilities.