### PR TITLE
Add support for category count

### DIFF
--- a/includes/Library/Categories.php
+++ b/includes/Library/Categories.php
@@ -116,7 +116,7 @@ class Categories {
 	private static function add_featured_category( $data ) {
 
 		$featured_category = array(
-			'id'    => '64552d7e137ae',
+			'id'    => '99262afa-322a-4f3c-92e4-c297ba153763',
 			'title' => 'featured',
 			'label' => 'Featured',
 		);

--- a/src/components/Modal/Sidebar/Categories.jsx
+++ b/src/components/Modal/Sidebar/Categories.jsx
@@ -26,10 +26,10 @@ const Categories = ({ type = 'patterns' }) => {
 	// Format categories for mobile dropdown
 	// prettier-ignore
 	const formattedCategoriesForMobile = useMemo(() => {
-		return data?.reduce((result, category) => {
+		return data?.reduce((result, category) => {            
             // Handle undefined values
             const label = category.label || '';
-            const count = category.count || '';
+            const count = category.count ?? '';
             const title = category.title || '';
             
             let formattedLabel = label;

--- a/src/components/Modal/Sidebar/Categories.jsx
+++ b/src/components/Modal/Sidebar/Categories.jsx
@@ -24,44 +24,41 @@ const Categories = ({ type = 'patterns' }) => {
 	const { data: allFavs } = usePatterns({ onlyFavorites: true, perPage: -1 });
 
 	// Format categories for mobile dropdown
-	const formattedCategoriesForMobile = useMemo(
-		() =>
-			data
-				?.reduce(
-					(result, category) => {
-						return [
-							...result,
-							{
-								label:
-									category.label +
-									' (' +
-									category.count +
-									')',
-								value: category.title,
-							},
-						];
-					},
-					[
-						{
-							value: 'favorites',
-							label:
-								__('Favorites', 'nfd-wonder-blocks') +
-								' (' +
-								(allFavs?.length ?? 0) +
-								')',
-						},
-					]
-				)
-				.sort((a, b) => {
-					if (a.value === 'favorites') {
-						return 1; // Move 'favorites' to the end
-					} else if (b.value === 'favorites') {
-						return -1; // Keep 'favorites' at the end
-					}
-					return 0; // Maintain the original order
-				}),
-		[data, allFavs]
-	);
+	// prettier-ignore
+	const formattedCategoriesForMobile = useMemo(() => {
+		return data?.reduce((result, category) => {
+            // Handle undefined values
+            const label = category.label || '';
+            const count = category.count || '';
+            const title = category.title || '';
+            
+            let formattedLabel = label;
+            
+            if (count) {
+                formattedLabel += ` (${count})`; // Include parentheses only when count is defined
+            }
+
+            return [
+                ...result,
+                { label: formattedLabel, value: title },
+            ];
+        },
+        [{
+            value: 'favorites',
+            label: `${__('Favorites', 'nfd-wonder-blocks')} (${
+                allFavs?.length ?? 0
+            })`,
+        }]
+        ).sort((a, b) => {
+            if (a.value === 'favorites') {
+                return 1; // Move 'favorites' to the end
+            } else if (b.value === 'favorites') {
+                return -1; // Keep 'favorites' at the end
+            }
+            
+            return 0; // Maintain the original order
+        });
+	}, [data, allFavs]);
 
 	// Store actions and states.
 	const {

--- a/src/components/Modal/Sidebar/ListElement.jsx
+++ b/src/components/Modal/Sidebar/ListElement.jsx
@@ -51,5 +51,6 @@ const ListElement = forwardRef(
 		);
 	}
 );
+
 export default ListElement;
 ListElement.displayName = 'ListElement';

--- a/src/hooks/useCategories.js
+++ b/src/hooks/useCategories.js
@@ -1,13 +1,13 @@
 /**
+ * External dependencies
+ */
+import useSWR from 'swr';
+
+/**
  * Internal dependencies
  */
 import { NFD_REST_URL } from '../constants';
 import { fetcher } from '../helpers/fetcher';
-
-/**
- * External dependencies
- */
-import useSWR from 'swr';
 
 const useCategories = (type = 'patterns') => {
 	const endpoint = type === 'patterns' ? 'categories' : 'templateCategories';

--- a/src/hooks/useCategories.js
+++ b/src/hooks/useCategories.js
@@ -13,9 +13,7 @@ const useCategories = (type = 'patterns') => {
 	const endpoint = type === 'patterns' ? 'categories' : 'templateCategories';
 
 	const { data, error, isValidating } = useSWR(
-		{
-			url: `${NFD_REST_URL}/${endpoint}`,
-		},
+		{ url: `${NFD_REST_URL}/${endpoint}` },
 		fetcher
 	);
 


### PR DESCRIPTION
This PR ensures that the UI will correctly show item count in each category. This expects https://patterns.hiive.cloud/categories to return `count` for each item in `data` array.

Can be safely merged even if the API still does not return count.