### PR TITLE
Use `enqueue_block_assets` for CSSUtilities

### DIFF
--- a/includes/CSSUtilities.php
+++ b/includes/CSSUtilities.php
@@ -8,8 +8,7 @@ class CSSUtilities {
 	 * Constructor.
 	 */
 	public function __construct() {
-		\add_action( 'wp_enqueue_scripts', array( $this, 'enqueue' ) );
-		\add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue' ) );
+		\add_action( 'enqueue_block_assets', array( $this, 'enqueue' ) );
 		\add_action( 'enqueue_nfd_wonder_blocks_utilities', array( $this, 'enqueue' ) );
 	}
 


### PR DESCRIPTION
1. Fixes CSS Utilities warning on 6.3 in both Onboarding and the Site Editor.
![Screenshot 2023-08-02 at 1 27 04 PM](https://github.com/newfold-labs/wp-module-patterns/assets/38878906/caca508a-8b34-4965-979e-e7267a0164c4)
2. `enqueue_block_assets` does the job of `wp_enqueue_scripts` and `enqueue_block_editor_assets`.