### PR TITLE
Add Update Notice for Minimum WP Version Requirement

### DIFF
--- a/includes/Library/Admin.php
+++ b/includes/Library/Admin.php
@@ -46,6 +46,7 @@ final class Admin {
 					'nonce'      => \wp_create_nonce( 'wp_rest' ),
 					'nfdRestURL' => \esc_url_raw( \rest_url( 'nfd-wonder-blocks/v1' ) ),
 					'assets'     => \esc_url( NFD_WONDER_BLOCKS_URL . '/assets' ),
+                    'wpVer'      => sanitize_text_field(get_bloginfo('version'))
 				)
 			);
 

--- a/includes/Library/Admin.php
+++ b/includes/Library/Admin.php
@@ -46,7 +46,7 @@ final class Admin {
 					'nonce'      => \wp_create_nonce( 'wp_rest' ),
 					'nfdRestURL' => \esc_url_raw( \rest_url( 'nfd-wonder-blocks/v1' ) ),
 					'assets'     => \esc_url( NFD_WONDER_BLOCKS_URL . '/assets' ),
-                    'wpVer'      => \esc_html(get_bloginfo('version'))
+					'wpVer'      => \esc_html( get_bloginfo( 'version' ) ),
 				)
 			);
 

--- a/includes/Library/Admin.php
+++ b/includes/Library/Admin.php
@@ -46,7 +46,7 @@ final class Admin {
 					'nonce'      => \wp_create_nonce( 'wp_rest' ),
 					'nfdRestURL' => \esc_url_raw( \rest_url( 'nfd-wonder-blocks/v1' ) ),
 					'assets'     => \esc_url( NFD_WONDER_BLOCKS_URL . '/assets' ),
-                    'wpVer'      => sanitize_text_field(get_bloginfo('version'))
+                    'wpVer'      => \esc_html(get_bloginfo('version'))
 				)
 			);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@newfold-labs/js-utility-ui-analytics": "1.2.0",
 				"@wordpress/icons": "^9.24.0",
 				"classnames": "^2.3.2",
-				"concurrently": "^8.0.1",
+				"compare-versions": "^6.1.0",
 				"lodash": "^4.17.21",
 				"react-intersection-observer": "^9.4.3",
 				"react-masonry-css": "^1.0.16",
@@ -23,6 +23,7 @@
 				"@wordpress/prettier-config": "^2.16.0",
 				"@wordpress/scripts": "^26.4.0",
 				"autoprefixer": "^10.4.14",
+				"concurrently": "^8.0.1",
 				"cssnano": "^6.0.1",
 				"eslint": "^8.40.0",
 				"eslint-plugin-prettier": "^4.2.1",
@@ -5487,6 +5488,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -6749,6 +6751,7 @@
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
 			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
 			"dependencies": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.1",
@@ -6871,6 +6874,11 @@
 			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
 			"dev": true
 		},
+		"node_modules/compare-versions": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.0.tgz",
+			"integrity": "sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg=="
+		},
 		"node_modules/compressible": {
 			"version": "2.0.18",
 			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -6941,6 +6949,7 @@
 			"version": "8.2.1",
 			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.1.tgz",
 			"integrity": "sha512-nVraf3aXOpIcNud5pB9M82p1tynmZkrSGQ1p6X/VY8cJ+2LMVqAgXsJxYYefACSHbTYlm92O1xuhdGTjwoEvbQ==",
+			"dev": true,
 			"dependencies": {
 				"chalk": "^4.1.2",
 				"date-fns": "^2.30.0",
@@ -6967,6 +6976,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -6981,6 +6991,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -6996,6 +7007,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -7007,6 +7019,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -7017,12 +7030,14 @@
 		"node_modules/concurrently/node_modules/color-name": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
 		},
 		"node_modules/concurrently/node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -7031,6 +7046,7 @@
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
 			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -7645,6 +7661,7 @@
 			"version": "2.30.0",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
 			"integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.21.0"
 			},
@@ -8322,6 +8339,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
 			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -10123,6 +10141,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
 			}
@@ -11115,6 +11134,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -17450,6 +17470,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -17634,6 +17655,7 @@
 			"version": "7.8.1",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
 			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+			"dev": true,
 			"dependencies": {
 				"tslib": "^2.1.0"
 			}
@@ -18055,6 +18077,7 @@
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
 			"integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -18239,7 +18262,8 @@
 		"node_modules/spawn-command": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
-			"integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ=="
+			"integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
+			"dev": true
 		},
 		"node_modules/spawnd": {
 			"version": "6.2.0",
@@ -18468,6 +18492,7 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -18480,7 +18505,8 @@
 		"node_modules/string-width/node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
 		},
 		"node_modules/string.prototype.matchall": {
 			"version": "4.0.9",
@@ -18550,6 +18576,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -19324,6 +19351,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
 			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+			"dev": true,
 			"bin": {
 				"tree-kill": "cli.js"
 			}
@@ -20609,6 +20637,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -20625,6 +20654,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -20639,6 +20669,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -20649,7 +20680,8 @@
 		"node_modules/wrap-ansi/node_modules/color-name": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
 		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
@@ -20719,6 +20751,7 @@
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
 			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -20742,6 +20775,7 @@
 			"version": "17.7.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
 			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
 			"dependencies": {
 				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
@@ -20768,6 +20802,7 @@
 			"version": "21.1.1",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
 			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
 			"engines": {
 				"node": ">=12"
 			}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"@wordpress/prettier-config": "^2.16.0",
 		"@wordpress/scripts": "^26.4.0",
 		"autoprefixer": "^10.4.14",
+		"concurrently": "^8.0.1",
 		"cssnano": "^6.0.1",
 		"eslint": "^8.40.0",
 		"eslint-plugin-prettier": "^4.2.1",
@@ -43,10 +44,10 @@
 		"@newfold-labs/js-utility-ui-analytics": "1.2.0",
 		"@wordpress/icons": "^9.24.0",
 		"classnames": "^2.3.2",
-		"concurrently": "^8.0.1",
 		"lodash": "^4.17.21",
 		"react-intersection-observer": "^9.4.3",
 		"react-masonry-css": "^1.0.16",
-		"swr": "^2.1.5"
+		"swr": "^2.1.5",
+		"compare-versions": "^6.1.0"
 	}
 }

--- a/src/components/Modal/Content/Content.jsx
+++ b/src/components/Modal/Content/Content.jsx
@@ -23,6 +23,7 @@ import NoResults from './DesignList/NoResults';
 import LoadingSpinner from './LoadingSpinner';
 import Skeleton from './Skeleton';
 import Spinner from './Spinner';
+import UpdateNotice from './UpdateNotice';
 
 const Content = () => {
 	const [ready, setReady] = useState(false);
@@ -104,6 +105,7 @@ const Content = () => {
 				{isSidebarLoading && !isError && <LoadingSpinner />}
 
 				<div className="nfd-wba-inset-0 nfd-wba-flex nfd-wba-grow nfd-wba-flex-col nfd-wba-px-4 nfd-wba-py-8 sm:nfd-wba-px-6">
+					<UpdateNotice />
 					<ContentTitle
 						activeTab={activeTab}
 						title={keywordsFilter}

--- a/src/components/Modal/Content/ContentTitle.jsx
+++ b/src/components/Modal/Content/ContentTitle.jsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';
-import { sprintf, __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/src/components/Modal/Content/UpdateNotice.jsx
+++ b/src/components/Modal/Content/UpdateNotice.jsx
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { compare } from 'compare-versions';
+
+/**
+ * WordPress dependencies
+ */
+import { Notice } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	BRAND_NAME,
+	MIN_REQUIRED_WP_VERSION,
+	WP_VERSION,
+} from '../../../constants';
+
+const UpdateNotice = () => {
+	if (compare(WP_VERSION, MIN_REQUIRED_WP_VERSION, '>=')) {
+		return null;
+	}
+
+	const updateURL = addQueryArgs('update-core.php');
+
+	const message = createInterpolateElement(
+		sprintf(
+			// translators: %s: brand name - 'Wonder Blocks'.
+			__(
+				'%s needs the latest version of WordPress, please <a>update your site</a>.',
+				'nfd-wonder-blocks'
+			),
+			BRAND_NAME
+		),
+		{
+			// eslint-disable-next-line jsx-a11y/anchor-has-content
+			a: <a href={updateURL} />,
+		}
+	);
+
+	return (
+		<Notice
+			className="nfd-wba-m-0 nfd-wba-mb-8"
+			isDismissible={false}
+			status="warning"
+		>
+			{message}
+		</Notice>
+	);
+};
+
+export default UpdateNotice;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,17 +1,15 @@
+export const BRAND_NAME = 'Wonder Blocks';
+export const WP_VERSION = window.nfdWonderBlocks?.wpVer || '';
+export const MIN_REQUIRED_WP_VERSION = '6.3.1';
 export const NFD_WONDER_BLOCKS_MODAL_ID = 'nfd-wba-modal';
 export const NFD_WONDER_BLOCKS_TOOLBAR_BUTTON_ID = 'nfd-wba-toolbar-button';
-
 export const NFD_REST_URL = window.nfdWonderBlocks?.nfdRestURL || '';
 export const WP_REST_NAMESPACE = '/wp/v2';
 export const SUPPORT_URL = window.nfdWonderBlocks?.supportURL || '#';
 export const INPUT_DEBOUNCE_TIME = 800;
 export const SITE_EDITOR_CATEGORIES = ['header', 'footer'];
-export const BRAND_NAME = 'Wonder Blocks';
-
 export const DEFAULT_ACTIVE_TAB = 'patterns';
 export const DEFAULT_PATTERNS_CATEGORY = 'featured';
 export const DEFAULT_TEMPLATES_CATEGORY = 'featured';
-
 export const WONDER_BLOCKS_BLANK_TEMPLATE_SLUG = 'wonder-blocks-blank-template';
-
 export const HIIVE_ANALYTICS_CATEGORY = 'wonder_blocks';


### PR DESCRIPTION
This PR introduces a new feature in the module that warns users when their WordPress installation does not meet the minimum version requirement for optimal functionality. The notice prompts users to update their WordPress installation to avoid potential issues.

- Adds a new **UpdateNotice** component that leverages Gutenberg's Notice component to display a warning message.

- Utilizes the compare-versions library to robustly compare the current WordPress version with the minimum required version.

- Introduces two new constants, WP_VERSION and MIN_REQUIRED_WP_VERSION, that hold the current WordPress version and the minimum required version, respectively.

![screenshot](https://github.com/newfold-labs/wp-module-patterns/assets/10332486/959007fe-49d9-4571-b2c2-1c9a3bcee096)

