### PR TITLE
Display Wonder Blocks patterns in core patterns modal

### DIFF
--- a/includes/Library/Admin.php
+++ b/includes/Library/Admin.php
@@ -56,9 +56,11 @@ final class Admin {
 	}
 
 	/**
-	 * Disable opening default WP Patterns modal on empty pages.
+	 * Register Block Patterns
 	 */
 	public function register_block_patterns() {
+
+		// Disable opening default WP Patterns modal on empty pages.
 		$patterns = \WP_Block_Patterns_Registry::get_instance()->get_all_registered();
 
 		foreach ( $patterns as $pattern ) {
@@ -66,6 +68,48 @@ final class Admin {
 				\unregister_block_pattern( $pattern['name'] );
 				$pattern['blockTypes'] = array_diff( $pattern['blockTypes'], array( 'core/post-content' ) );
 				\register_block_pattern( $pattern['name'], $pattern );
+			}
+		}
+
+		// Add Wonder Blocks patterns.
+		$wb_patterns = Items::get_data_from_transients( 'patterns' );
+
+		if ( is_array( $wb_patterns ) && ! empty( $wb_patterns ) ) {
+
+			$wb_pattern_categories = \get_transient( 'wba_patterns_categories' );
+
+			// Register Wonder Blocks pattern categories.
+			if ( is_array( $wb_pattern_categories ) && ! empty( $wb_pattern_categories ) ) {
+				foreach ( $wb_pattern_categories as $category ) {
+					register_block_pattern_category(
+						'wonder-blocks-' . $category['title'],
+						array( 'label' => 'Wonder Blocks - ' . $category['label'] )
+					);
+				}
+			}
+
+			foreach ( $wb_patterns as $pattern ) {
+
+				$categories = array();
+
+				// Build categories array.
+				if ( is_array( $pattern['categories'] ) && ! empty( $pattern['categories'] ) ) {
+					foreach ( $pattern['categories'] as $category ) {
+						$categories[] = 'wonder-blocks-' . $category;
+					}
+				} elseif ( is_string( $pattern['categories'] ) ) {
+					$categories[] = 'wonder-blocks-' . $pattern['categories'];
+				}
+
+				\register_block_pattern(
+					'wonder-blocks/' . $pattern['title'],
+					array(
+						'title'       => $pattern['title'],
+						'content'     => $pattern['content'],
+						'description' => $pattern['title'],
+						'categories'  => $categories,
+					)
+				);
 			}
 		}
 	}

--- a/includes/Library/Admin.php
+++ b/includes/Library/Admin.php
@@ -71,6 +71,14 @@ final class Admin {
 			}
 		}
 
+		// Remove Yith Wonder patterns.
+		$all_registered_patterns = \WP_Block_Patterns_Registry::get_instance()->get_all_registered();
+		foreach ( $all_registered_patterns as $pattern ) {
+			if ( strpos( $pattern['name'], 'yith-wonder/' ) !== false && ! in_array( 'yith-wonder-pages', $pattern['categories'], true ) ) {
+				\unregister_block_pattern( $pattern['name'] );
+			}
+		}
+
 		// Add Wonder Blocks patterns.
 		$wb_patterns = Items::get_data_from_transients( 'patterns' );
 

--- a/includes/Library/Items.php
+++ b/includes/Library/Items.php
@@ -63,7 +63,7 @@ class Items {
 		// Ensure we only get templates or patterns.
 		$id   = md5( serialize( $args ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 		$type = 'templates' === $type ? 'templates' : 'patterns';
-		$data = \get_transient( "wba_{$type}_{$id}" );
+		$data = self::get_data_from_transients( $type, $args );
 
 		if ( false === $data || ( \defined( 'NFD_WB_DEV_MODE' ) && NFD_WB_DEV_MODE ) ) {
 
@@ -84,6 +84,32 @@ class Items {
 
 		return $data;
 	}
+
+	/**
+	 * Get data from transients.
+	 *
+	 * @param string $type Type of items to get.
+	 * @param array  $args Array of arguments.
+	 *
+	 * @return array $data
+	 */
+	public static function get_data_from_transients( $type = 'patterns', $args = array() ) {
+		$args = wp_parse_args(
+			$args,
+			array(
+				'primary_type'   => SiteClassification::get_primary_type(),
+				'secondary_type' => SiteClassification::get_secondary_type(),
+			)
+		);
+
+		// Ensure we only get templates or patterns.
+		$id   = md5( serialize( $args ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		$type = 'templates' === $type ? 'templates' : 'patterns';
+		$data = \get_transient( "wba_{$type}_{$id}" );
+
+		return $data;
+	}
+
 
 	/**
 	 * Filter data by key and value.


### PR DESCRIPTION
This pull request introduces Wonder Blocks patterns directly into the WordPress Core Patterns modal. Users will now have immediate access to these new patterns, making it easier to insert them into posts and pages.

**Changes**

- Integrated Wonder Blocks patterns into the core Patterns modal via the register_block_patterns function.
- Added new categories, "Wonder Blocks - Category", to the Patterns modal for better organization.
- Unregistered Yith Wonder block patterns to maintain a clean user interface.

**Testing**

- Navigate to any post or page editor.
- Open the Block Inserter and navigate to Patterns tab.
- Browse to the "Wonder Blocks" categories.
- Confirm that the Wonder Blocks patterns are available and functional.

**Screenshots**

![Screenshot 2023-10-23 at 6 40 52 PM](https://github.com/newfold-labs/wp-module-patterns/assets/10332486/e6469b6c-3726-46dc-9c2f-8430dc135290)

![Screenshot 2023-10-23 at 6 41 11 PM](https://github.com/newfold-labs/wp-module-patterns/assets/10332486/d530df1d-aaaf-4028-b038-42de4a60219c)

