### PR TITLE
Add basic cypress test

### DIFF
--- a/tests/cypress/integration/wonder-blocks.cy.js
+++ b/tests/cypress/integration/wonder-blocks.cy.js
@@ -1,0 +1,41 @@
+// <reference types="Cypress" />
+
+describe( 'Wonder Blocks', function () {
+	before( () => {
+		cy.visit( '/wp-admin/post-new.php' );
+	} );
+
+	it( 'Wonder Blocks button exists', () => {
+		cy.get( '#nfd-wba-toolbar-button' ).should( 'exist' );
+	} );
+
+	it( 'Wonder Blocks button opens modal', () => {
+		cy.get( '#nfd-wba-toolbar-button' ).click();
+		cy.wait( 100 );
+		// body has class modal-open
+		cy.get( 'body' ).should( 'have.class', 'modal-open' );
+		// modal window exists
+		cy.get( '.nfd-wba-modal[role="dialog"]' ).should( 'be.visible' );
+	} );
+
+	it( 'Close buttons closes modal', () => {
+		cy.get(
+			'.nfd-wba-modal__header button[aria-label="Close dialog"]'
+		).should( 'exist' );
+		cy.get(
+			'.nfd-wba-modal__header button[aria-label="Close dialog"]'
+		).click();
+		cy.wait( 100 );
+		cy.get( 'body' ).should( 'not.have.class', 'modal-open' );
+		cy.get( '.nfd-wba-modal[role="dialog"]' ).should( 'not.exist' );
+	} );
+
+	it( 'ESC button closes modal too', () => {
+		cy.get( '#nfd-wba-toolbar-button' ).click();
+		cy.wait( 100 );
+		cy.get( '.nfd-wba-modal[role="dialog"]' ).should( 'be.visible' );
+		cy.get( 'body' ).type( '{esc}' );
+		cy.wait( 100 );
+		cy.get( '.nfd-wba-modal[role="dialog"]' ).should( 'not.exist' );
+	} );
+} );


### PR DESCRIPTION
This adds a basic cypress test to verify wonderblock button is present and functional.

Ideally, we can expand on this and include more tests to ensure the wonder block modal contains the expected content and the interface works as expected. These tests are run in every plugin PR so we can make sure modules function as expected with each update.

We can even stub/intercept the API endpoints in the test so we receive consistent responses which will be pulled in and tests can be run against that response.