### PR TITLE
Fix welcome guide interfering with cypress test

### DIFF
--- a/tests/cypress/integration/wonder-blocks.cy.js
+++ b/tests/cypress/integration/wonder-blocks.cy.js
@@ -6,6 +6,7 @@ describe( 'Wonder Blocks', function () {
 	} );
 
 	it( 'Wonder Blocks button exists', () => {
+		cy.get( 'body' ).click( { force: true } ); // clear welcome guide
 		cy.get( '#nfd-wba-toolbar-button' ).should( 'exist' );
 	} );
 


### PR DESCRIPTION
This forces a click on `body`, which closes gutenberg's welcome guide (which is open by default) so the test can proceed. If no welcome guide loads, this is just an extra click on the body element.

Currently, in the HostGator plugin, we're excluding this test. Once this is merged we can include this module's tests again.