### PR TITLE
Update URL for Satis

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Dynamic WordPress patterns library for WordPress sites at Newfold Digital.
 ### 1. Add the Newfold Satis to your `composer.json`.
 
 ```bash
-composer config repositories.newfold composer https://newfold.github.io/satis
+composer config repositories.newfold composer https://newfold-labs.github.io/satis
 ```
 
 ### 2. Require the `newfold-labs/wp-module-wp-module-patterns` package.


### PR DESCRIPTION
Updates the Satis url from `newfold.github.io` to the correct `newfold-labs.github.io`.