### PR TITLE
Fix wonder block button test

### DIFF
--- a/tests/cypress/integration/wonder-blocks.cy.js
+++ b/tests/cypress/integration/wonder-blocks.cy.js
@@ -1,42 +1,44 @@
 // <reference types="Cypress" />
 
-describe( 'Wonder Blocks', function () {
-	before( () => {
-		cy.visit( '/wp-admin/post-new.php' );
-	} );
+describe('Wonder Blocks', function () {
+	before(() => {
+		cy.visit('/wp-admin/post-new.php');
+	});
 
-	it( 'Wonder Blocks button exists', () => {
-		cy.get( 'body' ).click( { force: true } ); // clear welcome guide
-		cy.get( '#nfd-wba-toolbar-button' ).should( 'exist' );
-	} );
+	it('Wonder Blocks button exists', () => {
+		cy.get('#nfd-wba-toolbar-button').should('exist');
+	});
 
-	it( 'Wonder Blocks button opens modal', () => {
-		cy.get( '#nfd-wba-toolbar-button' ).click();
-		cy.wait( 100 );
+	it('Wonder Blocks button opens modal', () => {
+		cy.wait(1000);
+		cy.get('body').click({ force: true }); // clear welcome guide
+		cy.wait(100);
+		cy.get('#nfd-wba-toolbar-button button').click();
+		cy.wait(100);
 		// body has class modal-open
-		cy.get( 'body' ).should( 'have.class', 'modal-open' );
+		cy.get('body').should('have.class', 'modal-open');
 		// modal window exists
-		cy.get( '.nfd-wba-modal[role="dialog"]' ).should( 'be.visible' );
-	} );
+		cy.get('.nfd-wba-modal[role="dialog"]').should('be.visible');
+	});
 
-	it( 'Close buttons closes modal', () => {
+	it('Close buttons closes modal', () => {
 		cy.get(
 			'.nfd-wba-modal__header button[aria-label="Close dialog"]'
-		).should( 'exist' );
+		).should('exist');
 		cy.get(
 			'.nfd-wba-modal__header button[aria-label="Close dialog"]'
 		).click();
-		cy.wait( 100 );
-		cy.get( 'body' ).should( 'not.have.class', 'modal-open' );
-		cy.get( '.nfd-wba-modal[role="dialog"]' ).should( 'not.exist' );
-	} );
+		cy.wait(100);
+		cy.get('body').should('not.have.class', 'modal-open');
+		cy.get('.nfd-wba-modal[role="dialog"]').should('not.exist');
+	});
 
-	it( 'ESC button closes modal too', () => {
-		cy.get( '#nfd-wba-toolbar-button' ).click();
-		cy.wait( 100 );
-		cy.get( '.nfd-wba-modal[role="dialog"]' ).should( 'be.visible' );
-		cy.get( 'body' ).type( '{esc}' );
-		cy.wait( 100 );
-		cy.get( '.nfd-wba-modal[role="dialog"]' ).should( 'not.exist' );
-	} );
-} );
+	it('ESC button closes modal too', () => {
+		cy.get('#nfd-wba-toolbar-button button').click();
+		cy.wait(100);
+		cy.get('.nfd-wba-modal[role="dialog"]').should('be.visible');
+		cy.get('body').type('{esc}');
+		cy.wait(100);
+		cy.get('.nfd-wba-modal[role="dialog"]').should('not.exist');
+	});
+});


### PR DESCRIPTION
The test became outdated. This fix ensures the button is the target of clicks and that the welcome guide modal is closed at the proper time.

I have the test copied in the bluehost latest release so we don't need this to be released urgently, as the plugin test overrides this one, but will be good to have a working test in place here for the next release.