### PR TITLE
added semver format check for versions missing minor and patch

### DIFF
--- a/src/components/Modal/Content/UpdateNotice.jsx
+++ b/src/components/Modal/Content/UpdateNotice.jsx
@@ -21,7 +21,35 @@ import {
 } from '../../../constants';
 
 const UpdateNotice = () => {
-	if (compare(WP_VERSION, MIN_REQUIRED_WP_VERSION, '>=')) {
+
+	function formatVersion(version) {
+		const hasMinorAndPatch = /^\d+\.\d+\.\d+/.test(version);
+
+		if (hasMinorAndPatch) {
+			return version;
+		}
+
+		const [numericVersion, preRelease] = version.split(/-(.+)/);
+		const parts = numericVersion.split('.');
+
+		while (parts.length < 3) {
+			parts.push('0');
+		}
+
+		const normalizedVersion = preRelease
+			? `${parts.join('.')}-${preRelease}`
+			: parts.join('.');
+
+		return normalizedVersion;
+	}
+
+	if (
+		compare(
+			formatVersion(WP_VERSION),
+			formatVersion(MIN_REQUIRED_WP_VERSION),
+			'>='
+		)
+	) {
 		return null;
 	}
 

--- a/src/components/Modal/Content/UpdateNotice.jsx
+++ b/src/components/Modal/Content/UpdateNotice.jsx
@@ -10,6 +10,7 @@ import { Notice } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { formatVersion } from '../../../helpers';
 
 /**
  * Internal dependencies
@@ -21,28 +22,6 @@ import {
 } from '../../../constants';
 
 const UpdateNotice = () => {
-	/* To format the version to have semver MAJOR.MINOR.PATCH. Adding '0', if the MINOR or PATCH are missing  */
-	function formatVersion(version) {
-		const hasMinorAndPatch = /^\d+\.\d+\.\d+/.test(version);
-
-		if (hasMinorAndPatch) {
-			return version;
-		}
-		/* For a version that looks like 1.2.3-RC1, numericVersion = "1.2.3" rcSuffix = "RC1" */
-		const [numericVersion, rcSuffix] = version.split(/-(.+)/);
-		const versionParts = numericVersion.split('.');
-
-		while (versionParts.length < 3) {
-			versionParts.push('0');
-		}
-
-		const formattedVersion = rcSuffix
-			? `${versionParts.join('.')}-${rcSuffix}`
-			: versionParts.join('.');
-
-		return formattedVersion;
-	}
-
 	try {
 		if (
 			compare(

--- a/src/components/Modal/Content/UpdateNotice.jsx
+++ b/src/components/Modal/Content/UpdateNotice.jsx
@@ -21,35 +21,41 @@ import {
 } from '../../../constants';
 
 const UpdateNotice = () => {
-
+	/* To format the version to have semver MAJOR.MINOR.PATCH. Adding '0', if the MINOR or PATCH are missing  */
 	function formatVersion(version) {
 		const hasMinorAndPatch = /^\d+\.\d+\.\d+/.test(version);
 
 		if (hasMinorAndPatch) {
 			return version;
 		}
+		/* For a version that looks like 1.2.3-RC1, numericVersion = "1.2.3" rcSuffix = "RC1" */
+		const [numericVersion, rcSuffix] = version.split(/-(.+)/);
+		const versionParts = numericVersion.split('.');
 
-		const [numericVersion, preRelease] = version.split(/-(.+)/);
-		const parts = numericVersion.split('.');
-
-		while (parts.length < 3) {
-			parts.push('0');
+		while (versionParts.length < 3) {
+			versionParts.push('0');
 		}
 
-		const normalizedVersion = preRelease
-			? `${parts.join('.')}-${preRelease}`
-			: parts.join('.');
+		const formattedVersion = rcSuffix
+			? `${versionParts.join('.')}-${rcSuffix}`
+			: versionParts.join('.');
 
-		return normalizedVersion;
+		return formattedVersion;
 	}
 
-	if (
-		compare(
-			formatVersion(WP_VERSION),
-			formatVersion(MIN_REQUIRED_WP_VERSION),
-			'>='
-		)
-	) {
+	try {
+		if (
+			compare(
+				formatVersion(WP_VERSION),
+				formatVersion(MIN_REQUIRED_WP_VERSION),
+				'>='
+			)
+		) {
+			return null;
+		}
+	} catch (error) {
+		// eslint-disable-next-line no-console
+		console.error('Error comparing versions:', error);
 		return null;
 	}
 

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -2,3 +2,4 @@ export * from './analytics';
 export * from './blockInserter';
 export * from './fetcher';
 export * from './optimizePreview';
+export * from './utils';

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -1,0 +1,21 @@
+/* To format the version to have semver MAJOR.MINOR.PATCH. Adding '0', if the MINOR or PATCH are missing  */
+export function formatVersion(version) {
+	const hasMinorAndPatch = /^\d+\.\d+\.\d+/.test(version);
+
+	if (hasMinorAndPatch) {
+		return version;
+	}
+	/* For a version that looks like 1.2.3-RC1, numericVersion = "1.2.3" rcSuffix = "RC1" */
+	const [numericVersion, rcSuffix] = version.split(/-(.+)/);
+	const versionParts = numericVersion.split('.');
+
+	while (versionParts.length < 3) {
+		versionParts.push('0');
+	}
+
+	const formattedVersion = rcSuffix
+		? `${versionParts.join('.')}-${rcSuffix}`
+		: versionParts.join('.');
+
+	return formattedVersion;
+}


### PR DESCRIPTION
Related JIRA : https://jira.newfold.com/browse/PRESS2-1879


## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

The compare-version library used in the <UpdateNotice /> component to compare wordpress versions throws an error when the semver format is not maintained as MAJOR.MINOR.PATCH. In case of 6.5rc-2, it is expecting the format to be 6.5.0rc-2, ie. it is missing the PATCH.  I have added 0 for versions missing the Minor and Patch in semver-version keeping the release suffix like RC or alpha, beta as is. 
Additionally put the code in try catch block to handle any errors and that the error doesn't stop the WonderBlocks modal from opening. 


## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
