### PR TITLE
WordPress 6.5: Update modal search bar CSS

### DIFF
--- a/src/styles/_form.scss
+++ b/src/styles/_form.scss
@@ -1,5 +1,7 @@
 /* -------------------------------------------------------------------------- */
+
 /*                                Form styles.                                */
+
 /* -------------------------------------------------------------------------- */
 @use "mixins" as m;
 
@@ -34,14 +36,17 @@
 }
 
 .components-search-control {
+
 	&.nfd-wba-keyword-filter {
+
 		.components-base-control__field {
 			align-items: center;
 			display: flex;
 			gap: 12px;
 			margin: 0;
 
-			.components-base-control__label {
+			.components-base-control__label,
+			.components-input-control__label {
 				margin: 0;
 				text-transform: none;
 				font-size: 14px;
@@ -50,7 +55,8 @@
 			}
 		}
 
-		input[type="search"].components-search-control__input {
+		input[type="search"].components-search-control__input,
+		input[type="search"].components-input-control__input {
 			border-radius: 8px;
 			font-size: 1rem;
 			height: 36px;
@@ -60,6 +66,17 @@
 				cursor: wait;
 				opacity: 1;
 			}
+		}
+
+		.components-input-base {
+			flex-direction: row;
+			align-items: center;
+			gap: 12px;
+		}
+
+		.components-input-control__container {
+			border-radius: 8px;
+			height: 36px;
 		}
 	}
 }


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
On older WP versions:
<img width="411" alt="image" src="https://github.com/newfold-labs/wp-module-patterns/assets/38878906/11dfca80-34ac-4625-88a0-70d8e7952ddb">

On version 6.5, the issue was:
![image](https://github.com/newfold-labs/wp-module-patterns/assets/38878906/41f8522e-1e48-4c9b-9b61-7638349bbe62)

After the fix:
<img width="349" alt="image" src="https://github.com/newfold-labs/wp-module-patterns/assets/38878906/6076ca04-b287-4608-9be0-b7e09e8bcd69">

This does not exactly match the older versions but works well with the new `SearchControl` component.
