### PR TITLE
Add validation to ensure label key is present before sending event to Hiive

### DIFF
--- a/src/helpers/analytics.js
+++ b/src/helpers/analytics.js
@@ -6,7 +6,7 @@ export const trackHiiveEvent = (action, data) => {
 	const labelKey = data.label_key;
 	if (labelKey && !data[labelKey]) {
 		// eslint-disable-next-line no-console
-		console.error(`Tracking event validation failed: '${labelKey}' is empty or not defined in the data.`, data);
+		console.error(`Missing or empty '${labelKey}' in Hiive event data`, data);
 		return;
 	}
 	

--- a/src/helpers/analytics.js
+++ b/src/helpers/analytics.js
@@ -5,6 +5,8 @@ export const trackHiiveEvent = (action, data) => {
 	// Check if the label key for the event is present and not empty
 	const labelKey = data.label_key;
 	if (labelKey && !data[labelKey]) {
+		// eslint-disable-next-line no-console
+		console.error(`Tracking event validation failed: '${labelKey}' is empty or not defined in the data.`, data);
 		return;
 	}
 	

--- a/src/helpers/analytics.js
+++ b/src/helpers/analytics.js
@@ -2,6 +2,12 @@ import { HiiveAnalytics, HiiveEvent } from "@newfold-labs/js-utility-ui-analytic
 import { HIIVE_ANALYTICS_CATEGORY } from "../constants";
 
 export const trackHiiveEvent = (action, data) => {
+	// Check if the label key for the event is present and not empty
+	const labelKey = data.label_key;
+	if (labelKey && !data[labelKey]) {
+		return;
+	}
+	
 	data = {
 		...data,
 		page: window.location.href, // todo: check if this is what we want.


### PR DESCRIPTION
## Proposed changes

This PR introduces a validation check in the trackHiiveEvent function to ensure that the event's label key is present and not empty before proceeding with sending the event to Hiive.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
