### PR TITLE
Remove the duplicate in About view

### DIFF
--- a/src/components/Modal/Content/Views/About.jsx
+++ b/src/components/Modal/Content/Views/About.jsx
@@ -61,8 +61,8 @@ const About = () => {
 					website needs.
 				</p>
 				<p className="nfd-wba-text-[15px]">
-					WonderBlocks is a feature of your {hostLabel} hosting plan and is powered by the{" "}
-					{hostPlugin}. You can update your WonderBlocks settings{" "}
+					WonderBlocks is a feature of your {hostLabel} hosting plan and is powered by 
+					{" " + hostPlugin}. You can update your WonderBlocks settings{" "}
 					<a href={settingsPageUrl} className="nfd-wba-text-blue-500 hover:nfd-wba-underline">
 						here
 					</a>


### PR DESCRIPTION
## Proposed changes

As each of the hosting brand plugins are prefixed with `The` the preceding `the` causes duplicates.

![CleanShot 2024-08-14 at 09 03 11@2x](https://github.com/user-attachments/assets/da1923d4-43d4-41c1-a26b-c804764141df)

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)