### PR TITLE
Update NODE_ENV for postcss in utils:prod script to minify utilities CSS file

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"lint:js": "wp-scripts lint-js ./src",
 		"lint:js:fix": "wp-scripts lint-js ./src --fix",
 		"utils:dev": "concurrently \"postcss ./css-utilities/utilities.css -o ./assets/build/utilities.css -w --env development\" \"esbuild --bundle ./assets/scripts/utilities.js --sourcemap --outfile=./assets/build/utilities.js --target=es2020 --watch\"",
-		"utils:prod": "concurrently \"NODE_ENVIRONMENT=production postcss ./css-utilities/utilities.css -o ./assets/build/utilities.css --env production\" \"esbuild --bundle ./assets/scripts/utilities.js --minify --outfile=./assets/build/utilities.js --target=es2020 && rm ./assets/build/utilities.js.map\"",
+		"utils:prod": "concurrently \"postcss ./css-utilities/utilities.css -o ./assets/build/utilities.css --env production\" \"esbuild --bundle ./assets/scripts/utilities.js --minify --outfile=./assets/build/utilities.js --target=es2020 && rm ./assets/build/utilities.js.map\"",
 		"json-server": "json-server --watch api.dev.json --port 3003"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"lint:js": "wp-scripts lint-js ./src",
 		"lint:js:fix": "wp-scripts lint-js ./src --fix",
 		"utils:dev": "concurrently \"postcss ./css-utilities/utilities.css -o ./assets/build/utilities.css -w --env development\" \"esbuild --bundle ./assets/scripts/utilities.js --sourcemap --outfile=./assets/build/utilities.js --target=es2020 --watch\"",
-		"utils:prod": "concurrently \"postcss ./css-utilities/utilities.css -o ./assets/build/utilities.css --env production\" \"esbuild --bundle ./assets/scripts/utilities.js --minify --outfile=./assets/build/utilities.js --target=es2020 && rm ./assets/build/utilities.js.map\"",
+		"utils:prod": "concurrently \"NODE_ENVIRONMENT=production postcss ./css-utilities/utilities.css -o ./assets/build/utilities.css --env production\" \"esbuild --bundle ./assets/scripts/utilities.js --minify --outfile=./assets/build/utilities.js --target=es2020 && rm ./assets/build/utilities.js.map\"",
 		"json-server": "json-server --watch api.dev.json --port 3003"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Proposed changes

The `postcss.config.js` is expecting `process.env.NODE_ENV === "production"` to enable minification in the utilities css file and the `--env` flag doesn't seem to be taking. This should cut about 20kb from this asset file frontend and admin 😎

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
