### PR TITLE
Fix minification using postcss detection of env

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,9 +1,9 @@
 const tailwind = require("./tailwind.config");
 const { resolve } = require("path");
 
-module.exports = () => ({
+module.exports = (ctx) => ({
 	ident: "postcss",
-	sourceMap: process.env.NODE_ENV !== "production",
+	sourceMap: ctx.env !== "production",
 	plugins: [
 		require("tailwindcss")({
 			...tailwind,
@@ -18,7 +18,7 @@ module.exports = () => ({
 			});
 		},
 		require("autoprefixer")({ grid: true }),
-		process.env.NODE_ENV === "production" &&
+		ctx.env === "production" &&
 			require("cssnano")({
 				preset: [
 					"default",


### PR DESCRIPTION
## Proposed changes

Uses `ctx.env` to detect `--env production` from npm script that was causing minification in the utilities file not to take.

Cuts 20kb from frontends and editor 😎

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video