### PR TITLE
PRESS0-1788 Load CSS and JS utilities from remote

### DIFF
--- a/includes/CSSUtilities.php
+++ b/includes/CSSUtilities.php
@@ -147,7 +147,7 @@ class CSSUtilities {
 	 * Get the version number for the asset, either from remote or fallback.
 	 *
 	 * @param string $remote_url The remote URL for the asset.
-	 * @return int The version number of the asset.
+	 * @return int|string The version number.
 	 */
 	private function get_asset_version( string $remote_url ) {
 		return $this->is_valid_remote_file( $remote_url ) ? $this->get_remote_assets_version() : NFD_WONDER_BLOCKS_VERSION;
@@ -173,7 +173,7 @@ class CSSUtilities {
 	/**
 	 * Get the version number for remote assets.
 	 *
-	 * @return int
+	 * @return int The version number.
 	 */
 	private function get_remote_assets_version() : int {
 		$version = get_transient('nfd_utilities_version');
@@ -188,6 +188,8 @@ class CSSUtilities {
 	
 	/**
 	 * Get the base URL
+	 * 
+	 * @return string The base URL.
 	 */
 	public function get_base_url(): string {
 		if ( defined( 'NFD_DATA_WB_DEV_MODE' ) && constant( 'NFD_DATA_WB_DEV_MODE' ) ) {

--- a/includes/CSSUtilities.php
+++ b/includes/CSSUtilities.php
@@ -2,7 +2,22 @@
 
 namespace NewfoldLabs\WP\Module\Patterns;
 
+use NewfoldLabs\WP\Module\Data\WonderBlocks\Requests\Fetch;
 class CSSUtilities {
+	
+	/**
+	 * The production base URL.
+	 *
+	 * @var string
+	 */
+	protected static $production_base_url = 'https://patterns.hiive.cloud';
+
+	/**
+	 * The local base URL.
+	 *
+	 * @var string
+	 */
+	protected static $local_base_url = 'http://localhost:8888';
 
 	/**
 	 * Constructor.
@@ -19,31 +34,51 @@ class CSSUtilities {
 	 */
 	public function enqueue() {
 
+		$base_url = $this->get_base_url();
+		
+		$remote_css = $base_url . '/assets/css/utilities.css';
+		$remote_js  = $base_url . '/assets/js/utilities.js';
+		
+		$css_url = $this->get_asset_url($remote_css, NFD_WONDER_BLOCKS_URL . '/assets/build/utilities.css');
+		$css_version = $this->get_asset_version($remote_css);
+
+		$js_url = $this->get_asset_url($remote_js, NFD_WONDER_BLOCKS_URL . '/assets/build/utilities.js');
+		$js_version = $this->get_asset_version($remote_js);
+
 		\wp_register_style( 
 			'nfd-wonder-blocks-utilities',
-			NFD_WONDER_BLOCKS_URL . '/assets/build/utilities.css',
+			$css_url,
 			array(),
-			NFD_WONDER_BLOCKS_VERSION
+			$css_version
 		);
-        
+
         \wp_register_script(
             'nfd-wonder-blocks-utilities',
-            NFD_WONDER_BLOCKS_URL . '/assets/build/utilities.js',
+            $js_url,
             array(),
-            NFD_WONDER_BLOCKS_VERSION
+            $js_version
         );
 
 		\wp_enqueue_style( 'nfd-wonder-blocks-utilities' );
 		\wp_enqueue_script( 'nfd-wonder-blocks-utilities' );
-		
+
 		\wp_add_inline_style( 'nfd-wonder-blocks-utilities', $this->get_inline_css() );
 	}
 	
+	/**
+	 * Generates inline CSS based on the current active theme.
+	 *
+	 * This function returns a set of CSS variables that are used to style the front-end 
+	 * and editor based on the active theme. Different themes may define their own color, 
+	 * font, and spacing presets, which are reflected in the generated CSS.
+	 *
+	 * @return string The generated CSS.
+	 */
 	private function get_inline_css() {
-		
+
 		$theme = \wp_get_theme()->get_template();
 		$css   = '';
-        
+
 		if ( 'yith-wonder' === $theme ) {
 			$css = "body, .editor-styles-wrapper {
                 /* Colors */
@@ -95,5 +130,70 @@ class CSSUtilities {
         }
 		
 		return $css;
+	}
+	
+	/**
+	 * Get the URL for the asset, checking if the remote URL is valid.
+	 *
+	 * @param string $remote_url The remote URL for the asset.
+	 * @param string $fallback_url The fallback URL if the remote asset is invalid.
+	 * @return string The valid URL for the asset.
+	 */
+	private function get_asset_url( string $remote_url, string $fallback_url ) : string {
+		return $this->is_valid_remote_file( $remote_url ) ? $remote_url : $fallback_url;
+	}
+
+	/**
+	 * Get the version number for the asset, either from remote or fallback.
+	 *
+	 * @param string $remote_url The remote URL for the asset.
+	 * @return int The version number of the asset.
+	 */
+	private function get_asset_version( string $remote_url ) {
+		return $this->is_valid_remote_file( $remote_url ) ? $this->get_remote_assets_version() : NFD_WONDER_BLOCKS_VERSION;
+	}
+	
+	/**
+	 * Check if a remote file is valid.
+	 *
+	 * @param string $url URL of the remote file.
+	 *
+	 * @return bool
+	 */
+	private function is_valid_remote_file( string $url ): bool {
+		$response = \wp_remote_get( $url, array( 'timeout' => 5 ) );
+		if ( is_wp_error( $response ) ) {
+			return false;
+		}
+
+		$status_code = \wp_remote_retrieve_response_code( $response );
+		return $status_code === 200;
+	}
+	
+	/**
+	 * Get the version number for remote assets.
+	 *
+	 * @return int
+	 */
+	private function get_remote_assets_version() : int {
+		$version = get_transient('nfd_utilities_version');
+		
+		if ( ! $version ) {
+			$version = time();
+			set_transient('nfd_utilities_version', $version, DAY_IN_SECONDS);
+		}
+		
+		return $version;
+	}
+	
+	/**
+	 * Get the base URL
+	 */
+	public function get_base_url(): string {
+		if ( defined( 'NFD_DATA_WB_DEV_MODE' ) && constant( 'NFD_DATA_WB_DEV_MODE' ) ) {
+			return self::$local_base_url;
+		}
+
+		return self::$production_base_url;
 	}
 }


### PR DESCRIPTION
## Proposed changes

This PR updates the CSSUtilities class to load CSS and JS assets from a remote URL. If the remote assets are unavailable, the fallback to local assets is triggered. 

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
