### PR TITLE
Fix/cache requests to remote asset checks

### DIFF
--- a/includes/Api/Controllers/CacheController.php
+++ b/includes/Api/Controllers/CacheController.php
@@ -4,6 +4,7 @@ namespace NewfoldLabs\WP\Module\Patterns\Api\Controllers;
 use NewfoldLabs\WP\Module\Patterns\SiteClassification;
 use NewfoldLabs\WP\Module\Data\WonderBlocks\Requests\Fetch as WonderBlocksFetchRequest;
 use NewfoldLabs\WP\Module\Data\WonderBlocks\WonderBlocks;
+use NewfoldLabs\WP\Module\Patterns\CSSUtilities;
 
 /**
  * Controller for cache.
@@ -71,6 +72,9 @@ class CacheController {
 
 			$response['categories'] = 'Cache cleared';
 		}
+		
+		// Refresh the CSS utilities assets.
+		CSSUtilities::get_instance()->refresh_assets();
 
 		return new \WP_REST_Response( $response, 200 );
 	}

--- a/includes/CSSUtilities.php
+++ b/includes/CSSUtilities.php
@@ -186,7 +186,7 @@ class CSSUtilities {
 		$last_refresh = get_option( 'nfd_utilities_last_refresh_time', 0 );
 		$current_time = time();
 		
-		if ( ( $current_time - $last_refresh ) > DAY_IN_SECONDS ) {
+		if ( ( $current_time - $last_refresh ) > DAY_IN_SECONDS || ( defined( 'NFD_DATA_WB_DEV_MODE' ) && constant( 'NFD_DATA_WB_DEV_MODE' ) ) ) {
 			$this->refresh_assets();
 			update_option( 'nfd_utilities_last_refresh_time', $current_time );
 		}

--- a/includes/CSSUtilities.php
+++ b/includes/CSSUtilities.php
@@ -38,14 +38,22 @@ class CSSUtilities {
 		
 		$remote_css = $base_url . '/assets/css/utilities.css';
 		$remote_js  = $base_url . '/assets/js/utilities.js';
-		
-		$css_url = $this->get_asset_url($remote_css, NFD_WONDER_BLOCKS_URL . '/assets/build/utilities.css');
-		$css_version = $this->get_asset_version($remote_css);
 
-		$js_url = $this->get_asset_url($remote_js, NFD_WONDER_BLOCKS_URL . '/assets/build/utilities.js');
-		$js_version = $this->get_asset_version($remote_js);
+		$css_url = $this->is_valid_remote_file( $remote_css )
+			? $remote_css
+			: constant( 'NFD_WONDER_BLOCKS_URL' ) . '/assets/build/utilities.css';
+		$css_version = $css_url === $remote_css
+			? strtotime( 'midnight' )
+			: constant( 'NFD_WONDER_BLOCKS_VERSION' );
 
-		\wp_register_style( 
+		$js_url = $this->is_valid_remote_file( $remote_js )
+			? $remote_js
+			: constant( 'NFD_WONDER_BLOCKS_URL' ) . '/assets/build/utilities.js';
+		$js_version = $js_url === $remote_js
+			? strtotime( 'midnight' )
+			: constant( 'NFD_WONDER_BLOCKS_VERSION' );
+
+		\wp_register_style(
 			'nfd-wonder-blocks-utilities',
 			$css_url,
 			array(),
@@ -131,28 +139,7 @@ class CSSUtilities {
 		
 		return $css;
 	}
-	
-	/**
-	 * Get the URL for the asset, checking if the remote URL is valid.
-	 *
-	 * @param string $remote_url The remote URL for the asset.
-	 * @param string $fallback_url The fallback URL if the remote asset is invalid.
-	 * @return string The valid URL for the asset.
-	 */
-	private function get_asset_url( string $remote_url, string $fallback_url ) : string {
-		return $this->is_valid_remote_file( $remote_url ) ? $remote_url : $fallback_url;
-	}
 
-	/**
-	 * Get the version number for the asset, either from remote or fallback.
-	 *
-	 * @param string $remote_url The remote URL for the asset.
-	 * @return int|string The version number.
-	 */
-	private function get_asset_version( string $remote_url ) {
-		return $this->is_valid_remote_file( $remote_url ) ? $this->get_remote_assets_version() : NFD_WONDER_BLOCKS_VERSION;
-	}
-	
 	/**
 	 * Check if a remote file is valid.
 	 *
@@ -181,22 +168,6 @@ class CSSUtilities {
 		return 200 === intval( $status_code );
 	}
 
-	/**
-	 * Get the version number for remote assets.
-	 *
-	 * @return int The version number.
-	 */
-	private function get_remote_assets_version() : int {
-		$version = get_transient('nfd_utilities_version');
-		
-		if ( ! $version ) {
-			$version = time();
-			set_transient('nfd_utilities_version', $version, DAY_IN_SECONDS);
-		}
-		
-		return $version;
-	}
-	
 	/**
 	 * Get the base URL
 	 * 

--- a/includes/Patterns.php
+++ b/includes/Patterns.php
@@ -35,7 +35,8 @@ class Patterns {
 			new CTA();
 		}
 
-		new CSSUtilities();
+		CSSUtilities::get_instance();
+
 		new RestApi();
 		new BlockStyles();
 	}


### PR DESCRIPTION
## Proposed changes

Currently, [‎CSSUtilities::is_valid_remote_file()](https://github.com/newfold-labs/wp-module-patterns/blob/df06479f0715d40e4aadfc299e77c9062c9165db/includes/CSSUtilities.php#L163-L171) is not cached, resulting in eight remote calls when loading the WordPress editor as each of the [CSS and JS's location and version are determined](https://github.com/newfold-labs/wp-module-patterns/blob/df06479f0715d40e4aadfc299e77c9062c9165db/includes/CSSUtilities.php#L42-L46), once through `_wp_get_iframed_editor_assets()` and once through `wp_common_block_scripts_and_styles()`.

This PR:

* (primarily) caches that remote request https://github.com/newfold-labs/wp-module-patterns/commit/4bf6ed5193b6ee832d1386b6f32b256833f15a30
*  removes [the once-daily caching](https://github.com/newfold-labs/wp-module-patterns/blob/df06479f0715d40e4aadfc299e77c9062c9165db/includes/CSSUtilities.php#L173-L187) of `time()` as a once-per-day changing value with `strtotime( 'midnight' )`
* removes the [`::get_asset_url()` and `::get_asset_version()`](https://github.com/newfold-labs/wp-module-patterns/blob/df06479f0715d40e4aadfc299e77c9062c9165db/includes/CSSUtilities.php#L135-L154) functions in favour of ternary operations

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
