### PR TITLE
Use Button(s) on Edit Screen, Show Button on Edit Posts, Allow Users to Disable

### DIFF
--- a/includes/Admin/CTA.php
+++ b/includes/Admin/CTA.php
@@ -175,7 +175,7 @@ class CTA {
         if ($screen->id === 'edit-post') {
             $url = admin_url('post-new.php?wb-library=patterns&wb-category=text');
         } elseif ($screen->id === 'edit-page') {
-            $url = admin_url('post-new.php?post_type=page&wb-library=templates');
+            $url = admin_url('post-new.php?post_type=page&wb-library=patterns&wb-category=features');
         } else {
             // Default fallback URL
             $url = admin_url('post-new.php?wb-library=patterns');

--- a/includes/Admin/CTA.php
+++ b/includes/Admin/CTA.php
@@ -184,7 +184,7 @@ class CTA {
         $svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="2.25 6 19.5 13.5" width="18px" height="20px"><path stroke-linecap="round" stroke-linejoin="round" d="M3.34 7.754c0-.552.447-.999.999-.999h5.328a1 1 0 0 1 .999.999v3.329a1 1 0 0 1-.999.999H4.339a.999.999 0 0 1-.999-.999V7.754Zm10.655 1.331a1 1 0 0 1 .999-.998h4.662c.552 0 .999.447.999.998v7.326a.999.999 0 0 1-.999.999h-4.662a1 1 0 0 1-.999-.999V9.085Zm-9.323 6.66a1 1 0 0 1 .998-.999h4.662a1 1 0 0 1 .999.999v1.998a1 1 0 0 1-.999.999H5.67a1 1 0 0 1-.998-.999v-1.998Z" style="fill:none;stroke-width:1.5px;paint-order:stroke;stroke:currentColor"/></svg>';
 
         $cta_text = sprintf(
-            __('%1$sAdd From WonderBlocks%2$s', 'nfd-wonder-blocks'),
+            __('%1$sAdd With WonderBlocks%2$s', 'nfd-wonder-blocks'),
             '<a class="page-title-action" href="' . esc_url($url) . '">' . $svg . '<span class="text">',
             '</span></a>'
         );

--- a/includes/Admin/CTA.php
+++ b/includes/Admin/CTA.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace NewfoldLabs\WP\Module\Patterns\Admin;
 
 /**
@@ -7,87 +6,255 @@ namespace NewfoldLabs\WP\Module\Patterns\Admin;
  */
 class CTA {
 
-	/**
-	 * Constructor.
-	 */
-	public function __construct() {
+    /**
+     * WordPress option name for posts
+     */
+    const POST_OPTION_NAME = 'nfd_wb_cta_enabled_posts';
 
-		if ( ! $this->is_edit_page_screen() ) {
-			return;
-		}
+    /**
+     * WordPress option name for pages
+     */
+    const PAGE_OPTION_NAME = 'nfd_wb_cta_enabled_pages';
 
-		\add_action( 'admin_footer', array( $this, 'add_cta_to_add_new_button' ) );
-		\add_action( 'admin_head', array( $this, 'add_style' ) );
-	}
+    /**
+     * Nonce action name
+     */
+    const NONCE_ACTION = 'nfd_wonderblocks_toggle';
 
-	/**
-	 * Add custom HTML to the Add New button on the Pages screen.
-	 */
-	public function add_cta_to_add_new_button() {
-		$cta_text = sprintf(
-			// Translators: %1$s is the opening anchor tag, %2$s is the closing anchor tag.
-			__( 'Create pages fast with the %1$sWonderBlocks Library%2$s.', 'nfd-wonder-blocks' ),
-			'<a href=\"' . \esc_url( \admin_url( 'post-new.php?post_type=page&wb-library=templates' ) ) . '\">',
-			'</a>'
-		);
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        // Initialize options if they don't exist
+        $this->maybe_init_options();
 
-		?>
-		<script>
-			document.addEventListener('DOMContentLoaded', function() {
-				let pageTitleAction = document.querySelector('.wrap .page-title-action');
-				if (pageTitleAction) {
-					let newElement = document.createElement('span');
-					newElement.innerHTML = "<?php echo $cta_text; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>"; 
-					newElement.classList.add('nfd-wba-cta-edit-screen');
-					pageTitleAction.insertAdjacentElement('afterend', newElement);
-				}
-			});
-		</script>
-		<?php
-	}
+        // Global AJAX handler registration
+        add_action('wp_ajax_toggle_wonderblocks_cta', array($this, 'handle_ajax_toggle'));
 
-	/**
-	 * Add a style tag to the head of the edit pages screen.
-	 */
-	public function add_style() {
-		?>
-		<style>
-			:root {
-				--nfd-wba-cta-text-color: #1e1e1e;
-			}
+        if (!$this->is_core_post_type()) {
+            return;
+        }
 
-			.nfd-wba-cta-edit-screen {
-				font-size: 16px;
-				line-height: 19px;
-				top: -3px;
-				position: relative;
-				margin-left: 16px;
-				color: var(--nfd-wba-cta-text-color);
-			}
+        add_action('admin_head', array($this, 'add_style'));
+        add_action('admin_footer', array($this, 'add_toggle_script'));
+        add_action('admin_footer', array($this, 'add_cta_to_add_new_button'));
+        add_filter('screen_settings', array($this, 'add_screen_option_html'), 10, 2);
+    }
 
-			.nfd-wba-cta-edit-screen a {
-				text-decoration: none;
-			}
+    /**
+     * Initialize options if they don't exist
+     */
+    private function maybe_init_options() {
+        if (false === get_option(self::POST_OPTION_NAME)) {
+            add_option(self::POST_OPTION_NAME, true);
+        }
+        if (false === get_option(self::PAGE_OPTION_NAME)) {
+            add_option(self::PAGE_OPTION_NAME, true);
+        }
+    }
 
-			@media only screen and (max-width: 960px) {
-				.nfd-wba-cta-edit-screen {
-					display: block;
-					margin-left: 0;
-					margin-top: 8px;
-				}
-			}
-		</style>
-		<?php
-	}
+    /**
+     * Get the appropriate option name based on screen
+     */
+    private function get_option_name_for_screen($screen_id) {
+        return $screen_id === 'edit-page' ? self::PAGE_OPTION_NAME : self::POST_OPTION_NAME;
+    }
 
-	/**
-	 * Check if the current page is the edit pages screen.
-	 *
-	 * @return bool
-	 */
-	private function is_edit_page_screen() {
-		global $pagenow;
+    /**
+     * Handle the AJAX toggle
+     */
+    public function handle_ajax_toggle() {
+        check_ajax_referer(self::NONCE_ACTION, 'nonce');
 
-		return 'edit.php' === $pagenow && isset( $_GET['post_type'] ) && 'page' === $_GET['post_type']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	}
+        if (!current_user_can('manage_options')) {
+            wp_die('', '', 403);
+        }
+
+        $screen_id = isset($_POST['screen_id']) ? sanitize_text_field($_POST['screen_id']) : 'edit-post';
+        $enabled = (bool) ($_POST['enabled'] === 'true');
+        $option_name = $this->get_option_name_for_screen($screen_id);
+
+        $updated = update_option($option_name, $enabled);
+
+        if ($updated) {
+            wp_send_json_success([
+                'enabled' => $enabled,
+                'option_name' => $option_name,
+                'screen_id' => $screen_id
+            ]);
+        } else {
+            wp_send_json_error('Failed to update option');
+        }
+    }
+
+    /**
+     * Add the screen option HTML
+     */
+    public function add_screen_option_html($settings, $screen) {
+        if (!in_array($screen->id, array('edit-page', 'edit-post'), true)) {
+            return $settings;
+        }
+
+        $option_name = $this->get_option_name_for_screen($screen->id);
+        $enabled = get_option($option_name);
+
+        $html = '<fieldset class="metabox-prefs wonderblocks">';
+        $html .= '<legend>' . esc_html__('WonderBlocks', 'nfd-wonder-blocks') . '</legend>';
+        $html .= '<label>';
+        $html .= '<input type="checkbox" id="wonderblocks-toggle"' . checked($enabled, true, false) . ' /> ';
+        $html .= esc_html__('Show WonderBlocks Button', 'nfd-wonder-blocks');
+        $html .= '</label>';
+        $html .= '</fieldset>';
+        $html .= wp_nonce_field(self::NONCE_ACTION, 'wonderblocks_nonce', true, false);
+
+        $allowed_html = array(
+            'fieldset' => array(
+                'class' => true,
+            ),
+            'legend' => array(),
+            'label' => array(),
+            'input' => array(
+                'type' => true,
+                'id' => true,
+                'checked' => true,
+                'name' => true,
+                'value' => true,
+            ),
+        );
+
+        return wp_kses($settings . $html, $allowed_html);
+    }
+
+    /**
+     * Add toggle script to footer
+     */
+    public function add_toggle_script() {
+        $screen = \get_current_screen();
+        ?>
+        <script>
+            jQuery(document).ready(function($) {
+                $('#wonderblocks-toggle').on('change', function() {
+                    const enabled = this.checked ? 'true' : 'false';
+                    $.post(ajaxurl, {
+                        action: 'toggle_wonderblocks_cta',
+                        nonce: $('#wonderblocks_nonce').val(),
+                        enabled: enabled,
+                        screen_id: '<?php echo esc_js($screen->id); ?>'
+                    })
+                    .done(function(response) {
+                        if (response.success) {
+                            window.location.reload();
+                        } else {
+                            $('#wonderblocks-toggle').prop('checked', !this.checked);
+                            console.error('Failed to update WonderBlocks setting:', response);
+                        }
+                    })
+                    .fail(function(jqXHR, textStatus, errorThrown) {
+                        $('#wonderblocks-toggle').prop('checked', !this.checked);
+                        console.error('AJAX request failed:', textStatus, errorThrown);
+                    });
+                });
+            });
+        </script>
+        <?php
+    }
+
+    /**
+     * Add CTA to Add New button
+     */
+    public function add_cta_to_add_new_button() {
+        $screen = \get_current_screen();
+        $option_name = $this->get_option_name_for_screen($screen->id);
+        $enabled = get_option($option_name);
+        
+        if (!$enabled) {
+            return;
+        }
+
+        // Set the URL based on screen type
+        if ($screen->id === 'edit-post') {
+            $url = admin_url('post-new.php?wb-library=patterns&wb-category=text');
+        } elseif ($screen->id === 'edit-page') {
+            $url = admin_url('post-new.php?post_type=page&wb-library=templates');
+        } else {
+            // Default fallback URL
+            $url = admin_url('post-new.php?wb-library=patterns');
+        }
+
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="2.25 6 19.5 13.5" width="18px" height="20px"><path stroke-linecap="round" stroke-linejoin="round" d="M3.34 7.754c0-.552.447-.999.999-.999h5.328a1 1 0 0 1 .999.999v3.329a1 1 0 0 1-.999.999H4.339a.999.999 0 0 1-.999-.999V7.754Zm10.655 1.331a1 1 0 0 1 .999-.998h4.662c.552 0 .999.447.999.998v7.326a.999.999 0 0 1-.999.999h-4.662a1 1 0 0 1-.999-.999V9.085Zm-9.323 6.66a1 1 0 0 1 .998-.999h4.662a1 1 0 0 1 .999.999v1.998a1 1 0 0 1-.999.999H5.67a1 1 0 0 1-.998-.999v-1.998Z" style="fill:none;stroke-width:1.5px;paint-order:stroke;stroke:currentColor"/></svg>';
+
+        $cta_text = sprintf(
+            __('%1$sAdd From WonderBlocks%2$s', 'nfd-wonder-blocks'),
+            '<a class="page-title-action" href="' . esc_url($url) . '">' . $svg . '<span class="text">',
+            '</span></a>'
+        );
+
+        ?>
+        <script>
+            document.addEventListener('DOMContentLoaded', function() {
+                const pageTitleAction = document.querySelector('.wrap .page-title-action');
+                if (pageTitleAction) {
+                    const newElement = document.createElement('div');
+                    newElement.innerHTML = <?php echo wp_json_encode($cta_text); ?>;
+                    newElement.classList.add('nfd-wba-cta-edit-screen');
+                    pageTitleAction.insertAdjacentElement('afterend', newElement);
+                }
+            });
+        </script>
+        <?php
+    }
+
+    /**
+     * Add styles for the CTA
+     */
+    public function add_style() {
+        ?>
+        <style>
+            .nfd-wba-cta-edit-screen {
+                display: inline-flex;
+            }
+            .nfd-wba-cta-edit-screen .page-title-action {
+                align-items: center;
+                border-color: #3d7e29;
+                color: #3d7e29;
+            }
+            .nfd-wba-cta-edit-screen .page-title-action:hover,
+            .nfd-wba-cta-edit-screen .page-title-action:active {
+                border-color: #2f621f;
+                color: #2f621f;
+            }
+            .nfd-wba-cta-edit-screen .page-title-action:focus {
+                border-color: #2f621f;
+                box-shadow: 0 0 0 1px #2f621f;
+            }
+            .nfd-wba-cta-edit-screen svg {
+                margin-right: 5px;
+                position: relative;
+                top: 4px;
+            }
+        </style>
+        <?php
+    }
+
+    /**
+     * Check if we're on the edit pages screen
+     */
+    private function is_core_post_type() {
+        if (!is_admin() || !is_user_logged_in()) {
+            return false;
+        }
+
+        global $pagenow, $typenow;
+        
+        $is_core_post_type = ('edit.php' === $pagenow && (
+            // Default post type (no post_type parameter)
+            (!isset($_GET['post_type']) && empty($typenow)) ||
+            // Explicit post type check
+            (isset($_GET['post_type']) && in_array($_GET['post_type'], array('post', 'page'), true)) ||
+            // Fallback to typenow
+            in_array($typenow, array('post', 'page'), true)
+        ));
+        
+        return $is_core_post_type;
+    }
 }

--- a/includes/Admin/CTA.php
+++ b/includes/Admin/CTA.php
@@ -6,260 +6,290 @@ namespace NewfoldLabs\WP\Module\Patterns\Admin;
  */
 class CTA {
 
-    /**
-     * WordPress option name for posts
-     */
-    const POST_OPTION_NAME = 'nfd_wb_cta_enabled_posts';
+	/**
+	 * WordPress option name for posts
+	 */
+	const POST_OPTION_NAME = 'nfd_wb_cta_enabled_posts';
 
-    /**
-     * WordPress option name for pages
-     */
-    const PAGE_OPTION_NAME = 'nfd_wb_cta_enabled_pages';
+	/**
+	 * WordPress option name for pages
+	 */
+	const PAGE_OPTION_NAME = 'nfd_wb_cta_enabled_pages';
 
-    /**
-     * Nonce action name
-     */
-    const NONCE_ACTION = 'nfd_wonderblocks_toggle';
+	/**
+	 * Nonce action name
+	 */
+	const NONCE_ACTION = 'nfd_wonderblocks_toggle';
 
-    /**
-     * Constructor.
-     */
-    public function __construct() {
-        // Initialize options if they don't exist
-        $this->maybe_init_options();
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
 
-        // Global AJAX handler registration
-        add_action('wp_ajax_toggle_wonderblocks_cta', array($this, 'handle_ajax_toggle'));
+		$this->maybe_init_options();
 
-        if (!$this->is_core_post_type()) {
-            return;
-        }
+		\add_action( 'wp_ajax_toggle_wonderblocks_cta', array( $this, 'handle_ajax_toggle' ) );
 
-        add_action('admin_head', array($this, 'add_style'));
-        add_action('admin_footer', array($this, 'add_toggle_script'));
-        add_action('admin_footer', array($this, 'add_cta_to_add_new_button'));
-        add_filter('screen_settings', array($this, 'add_screen_option_html'), 10, 2);
-    }
+		if ( ! $this->is_core_post_type() ) {
+			return;
+		}
 
-    /**
-     * Initialize options if they don't exist
-     */
-    private function maybe_init_options() {
-        if (false === get_option(self::POST_OPTION_NAME)) {
-            add_option(self::POST_OPTION_NAME, true);
-        }
-        if (false === get_option(self::PAGE_OPTION_NAME)) {
-            add_option(self::PAGE_OPTION_NAME, true);
-        }
-    }
+		\add_action( 'admin_head', array( $this, 'add_style' ) );
+		\add_action( 'admin_footer', array( $this, 'add_cta_to_add_new_button' ), 10 );
+		\add_action( 'admin_footer', array( $this, 'add_toggle_script' ), 20 );
+		\add_filter( 'screen_settings', array( $this, 'add_screen_option_html' ), 10, 2 );
+	}
 
-    /**
-     * Get the appropriate option name based on screen
-     */
-    private function get_option_name_for_screen($screen_id) {
-        return $screen_id === 'edit-page' ? self::PAGE_OPTION_NAME : self::POST_OPTION_NAME;
-    }
+	/**
+	 * Initialize options if they don't exist
+	 */
+	private function maybe_init_options() {
+		if ( false === get_option( self::POST_OPTION_NAME ) ) {
+			add_option( self::POST_OPTION_NAME, true );
+		}
+		if ( false === get_option( self::PAGE_OPTION_NAME ) ) {
+			add_option( self::PAGE_OPTION_NAME, true );
+		}
+	}
 
-    /**
-     * Handle the AJAX toggle
-     */
-    public function handle_ajax_toggle() {
-        check_ajax_referer(self::NONCE_ACTION, 'nonce');
+	/**
+	 * Get the appropriate option name based on screen
+	 *
+	 * @param string $screen_id The screen ID
+	 */
+	private function get_option_name_for_screen( $screen_id ) {
+		return 'edit-page' === $screen_id ? self::PAGE_OPTION_NAME : self::POST_OPTION_NAME;
+	}
 
-        if (!current_user_can('manage_options')) {
-            wp_die('', '', 403);
-        }
+	/**
+	 * Handle the AJAX toggle
+	 */
+	public function handle_ajax_toggle() {
+		\check_ajax_referer( self::NONCE_ACTION, 'nonce' );
 
-        $screen_id = isset($_POST['screen_id']) ? sanitize_text_field($_POST['screen_id']) : 'edit-post';
-        $enabled = (bool) ($_POST['enabled'] === 'true');
-        $option_name = $this->get_option_name_for_screen($screen_id);
+		if ( ! \current_user_can( 'manage_options' ) ) {
+			\wp_die( '', '', 403 );
+		}
 
-        $updated = update_option($option_name, $enabled);
+		$screen_id   = isset( $_POST['screen_id'] ) ? \sanitize_text_field( $_POST['screen_id'] ) : 'edit-post';
+		$enabled     = (bool) ( 'true' === $_POST['nfd_wba_cta_button'] );
+		$option_name = $this->get_option_name_for_screen( $screen_id );
 
-        if ($updated) {
-            wp_send_json_success([
-                'enabled' => $enabled,
-                'option_name' => $option_name,
-                'screen_id' => $screen_id
-            ]);
-        } else {
-            wp_send_json_error('Failed to update option');
-        }
-    }
+		$updated = \update_option( $option_name, $enabled );
 
-    /**
-     * Add the screen option HTML
-     */
-    public function add_screen_option_html($settings, $screen) {
-        if (!in_array($screen->id, array('edit-page', 'edit-post'), true)) {
-            return $settings;
-        }
+		if ( $updated ) {
+			\wp_send_json_success(
+				array(
+					'enabled'     => $enabled,
+					'option_name' => $option_name,
+					'screen_id'   => $screen_id,
+				)
+			);
+		} else {
+			\wp_send_json_error( 'Failed to update option' );
+		}
+	}
 
-        $option_name = $this->get_option_name_for_screen($screen->id);
-        $enabled = get_option($option_name);
+	/**
+	 * Add the screen option HTML
+	 *
+	 * @param string $settings The current screen settings
+	 * @param object $screen The current screen object
+	 */
+	public function add_screen_option_html( $settings, $screen ) {
+		if ( ! \in_array( $screen->id, array( 'edit-page', 'edit-post' ), true ) ) {
+			return $settings;
+		}
 
-        $html = '<fieldset class="metabox-prefs wonderblocks">';
-        $html .= '<legend>' . esc_html__('WonderBlocks', 'nfd-wonder-blocks') . '</legend>';
-        $html .= '<label>';
-        $html .= '<input type="checkbox" id="wonderblocks-toggle"' . checked($enabled, true, false) . ' /> ';
-        $html .= esc_html__('Show WonderBlocks Button', 'nfd-wonder-blocks');
-        $html .= '</label>';
-        $html .= '</fieldset>';
-        $html .= wp_nonce_field(self::NONCE_ACTION, 'wonderblocks_nonce', true, false);
+		$option_name = $this->get_option_name_for_screen( $screen->id );
+		$enabled     = \get_option( $option_name, true );
 
-        $allowed_html = array(
-            'fieldset' => array(
-                'class' => true,
-            ),
-            'legend' => array(),
-            'label' => array(),
-            'input' => array(
-                'type' => true,
-                'id' => true,
-                'checked' => true,
-                'name' => true,
-                'value' => true,
-            ),
-        );
+		$html  = '<fieldset class="metabox-prefs wonderblocks">';
+		$html .= '<legend>' . esc_html__( 'WonderBlocks', 'nfd-wonder-blocks' ) . '</legend>';
+		$html .= '<label>';
+		$html .= '<input type="checkbox" id="wonderblocks-toggle"' . checked( $enabled, true, false ) . ' /> ';
+		$html .= esc_html__( 'Show WonderBlocks Button', 'nfd-wonder-blocks' );
+		$html .= '</label>';
+		$html .= '</fieldset>';
+		$html .= \wp_nonce_field( self::NONCE_ACTION, 'wonderblocks_nonce', true, false );
 
-        return wp_kses($settings . $html, $allowed_html);
-    }
+		$allowed_html = array(
+			'fieldset' => array(
+				'class' => true,
+			),
+			'legend'   => array(),
+			'label'    => array(),
+			'input'    => array(
+				'type'    => true,
+				'id'      => true,
+				'checked' => true,
+				'name'    => true,
+				'value'   => true,
+			),
+		);
 
-    /**
-     * Add toggle script to footer
-     */
-    public function add_toggle_script() {
-        $screen = \get_current_screen();
-        ?>
-        <script>
-            jQuery(document).ready(function($) {
-                $('#wonderblocks-toggle').on('change', function() {
-                    const enabled = this.checked ? 'true' : 'false';
-                    $.post(ajaxurl, {
-                        action: 'toggle_wonderblocks_cta',
-                        nonce: $('#wonderblocks_nonce').val(),
-                        enabled: enabled,
-                        screen_id: '<?php echo esc_js($screen->id); ?>'
-                    })
-                    .done(function(response) {
-                        if (response.success) {
-                            window.location.reload();
-                        } else {
-                            $('#wonderblocks-toggle').prop('checked', !this.checked);
-                            console.error('Failed to update WonderBlocks setting:', response);
-                        }
-                    })
-                    .fail(function(jqXHR, textStatus, errorThrown) {
-                        $('#wonderblocks-toggle').prop('checked', !this.checked);
-                        console.error('AJAX request failed:', textStatus, errorThrown);
-                    });
-                });
-            });
-        </script>
-        <?php
-    }
+		return \wp_kses( $settings . $html, $allowed_html );
+	}
 
-    /**
-     * Add CTA to Add New button
-     */
-    public function add_cta_to_add_new_button() {
-        $screen = \get_current_screen();
-        $option_name = $this->get_option_name_for_screen($screen->id);
-        $enabled = get_option($option_name);
-        
-        if (!$enabled) {
-            return;
-        }
+	/**
+	 * Add toggle script to footer
+	 */
+	public function add_toggle_script() {
+		$screen = \get_current_screen();
+		?>
+		<script>
+			document.addEventListener("DOMContentLoaded", function () {
+				const toggle = document.getElementById("wonderblocks-toggle");
+				const nonceField = document.getElementById("wonderblocks_nonce");
+				const ajaxUrl = "<?php echo esc_js( admin_url( 'admin-ajax.php' ) ); ?>";
+				const screenId = "<?php echo esc_js( $screen->id ); ?>";
+				const ctaButton = document.querySelector('.nfd-wba-cta-edit-screen');
 
-        // Set the URL based on screen type
-        if ($screen->id === 'edit-post') {
-            $url = admin_url('post-new.php?wb-library=patterns&wb-category=text');
-        } elseif ($screen->id === 'edit-page') {
-            $url = admin_url('post-new.php?post_type=page&wb-library=patterns&wb-category=features');
-        } else {
-            // Default fallback URL
-            $url = admin_url('post-new.php?wb-library=patterns');
-        }
+				if (!toggle || !nonceField || !ctaButton) return;
 
-        $svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="2.25 6 19.5 13.5" width="19px" height="19px"><path stroke-linecap="round" stroke-linejoin="round" d="M3.34 7.754c0-.552.447-.999.999-.999h5.328a1 1 0 0 1 .999.999v3.329a1 1 0 0 1-.999.999H4.339a.999.999 0 0 1-.999-.999V7.754Zm10.655 1.331a1 1 0 0 1 .999-.998h4.662c.552 0 .999.447.999.998v7.326a.999.999 0 0 1-.999.999h-4.662a1 1 0 0 1-.999-.999V9.085Zm-9.323 6.66a1 1 0 0 1 .998-.999h4.662a1 1 0 0 1 .999.999v1.998a1 1 0 0 1-.999.999H5.67a1 1 0 0 1-.998-.999v-1.998Z" style="fill:none;stroke-width:1.5px;paint-order:stroke;stroke:currentColor"/></svg>';
+				toggle.addEventListener("change", function () {
+					const enabled = this.checked ? "true" : "false";
+					const data = new FormData();
+					data.append("action", "toggle_wonderblocks_cta");
+					data.append("nonce", nonceField.value);
+					data.append("nfd_wba_cta_button", enabled);
+					data.append("screen_id", screenId);
 
-        $cta_text = sprintf(
-            __('%1$sAdd With WonderBlocks%2$s', 'nfd-wonder-blocks'),
-            '<a class="page-title-action" href="' . esc_url($url) . '">' . $svg . '<span class="text">',
-            '</span></a>'
-        );
+					fetch(
+						ajaxUrl,
+						{
+							method: "POST",
+							body: data,
+						}
+					)
+					.then((response) => response.json())
+					.then((response) => {
+						if (response.success) {
+							ctaButton.style.display = enabled === "true" ? "inline-flex" : "none";
+						} else {
+							toggle.checked = !toggle.checked;
+							console.error("Failed to update WonderBlocks setting:", response);
+						}
+					})
+					.catch((error) => {
+						toggle.checked = !toggle.checked;
+						console.error("AJAX request failed:", error);
+					});
+				});
+			});
+		</script>
+		<?php
+	}
 
-        ?>
-        <script>
-            document.addEventListener('DOMContentLoaded', function() {
-                const pageTitleAction = document.querySelector('.wrap .page-title-action');
-                if (pageTitleAction) {
-                    const newElement = document.createElement('div');
-                    newElement.innerHTML = <?php echo wp_json_encode($cta_text); ?>;
-                    newElement.classList.add('nfd-wba-cta-edit-screen');
-                    pageTitleAction.insertAdjacentElement('afterend', newElement);
-                }
-            });
-        </script>
-        <?php
-    }
+	/**
+	 * Add CTA to Add New button
+	 */
+	public function add_cta_to_add_new_button() {
+		$screen      = \get_current_screen();
+		$option_name = $this->get_option_name_for_screen( $screen->id );
+		$enabled     = \get_option( $option_name, true );
 
-    /**
-     * Add styles for the CTA
-     */
-    public function add_style() {
-        ?>
-        <style>
-            .nfd-wba-cta-edit-screen {
-                display: inline-flex;
-            }
-            .nfd-wba-cta-edit-screen .page-title-action {
-                align-items: center;
-                border-color: #3d7e29;
-                color: #3d7e29;
-            }
-            .nfd-wba-cta-edit-screen .page-title-action:hover,
-            .nfd-wba-cta-edit-screen .page-title-action:active {
-                border-color: #2f621f;
-                color: #2f621f;
-            }
-            .nfd-wba-cta-edit-screen .page-title-action:focus {
-                border-color: #2f621f;
-                box-shadow: 0 0 0 1px #2f621f;
-            }
-            .nfd-wba-cta-edit-screen svg {
-                margin-right: 5px;
-                position: relative;
-                top: 4px;
-            }
+		// Set the URL based on screen type
+		if ( 'edit-post' === $screen->id ) {
+			$url = \admin_url( 'post-new.php?wb-library=patterns&wb-category=text' );
+		} elseif ( 'edit-page' === $screen->id ) {
+			$url = \admin_url( 'post-new.php?post_type=page&wb-library=patterns&wb-category=features' );
+		} else {
+			// Default fallback URL
+			$url = \admin_url( 'post-new.php?wb-library=patterns' );
+		}
+
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="2.25 6 19.5 13.5" width="19px" height="19px"><path stroke-linecap="round" stroke-linejoin="round" d="M3.34 7.754c0-.552.447-.999.999-.999h5.328a1 1 0 0 1 .999.999v3.329a1 1 0 0 1-.999.999H4.339a.999.999 0 0 1-.999-.999V7.754Zm10.655 1.331a1 1 0 0 1 .999-.998h4.662c.552 0 .999.447.999.998v7.326a.999.999 0 0 1-.999.999h-4.662a1 1 0 0 1-.999-.999V9.085Zm-9.323 6.66a1 1 0 0 1 .998-.999h4.662a1 1 0 0 1 .999.999v1.998a1 1 0 0 1-.999.999H5.67a1 1 0 0 1-.998-.999v-1.998Z" style="fill:none;stroke-width:1.5px;paint-order:stroke;stroke:currentColor"/></svg>';
+
+		$cta_text = sprintf(
+			/* translators: %1$s: opening anchor tag, %2$s: closing anchor tag */
+			_x(
+				'%1$sAdd With WonderBlocks%2$s',
+				'Button label',
+				'nfd-wonder-blocks'
+			),
+			'<a class="page-title-action" href="' . \esc_url( $url ) . '">' . $svg . '<span class="text">',
+			'</span></a>'
+		);
+
+		?>
+		<script>
+			document.addEventListener('DOMContentLoaded', function() {
+				const pageTitleAction = document.querySelector('.wrap .page-title-action');
+				if (pageTitleAction) {
+					const newElement = document.createElement('div');
+					newElement.innerHTML = <?php echo \wp_json_encode( $cta_text ); ?>;
+					newElement.classList.add('nfd-wba-cta-edit-screen');
+					if (!<?php echo json_encode( $enabled ); ?>) {
+						newElement.style.display = 'none';
+					}
+					pageTitleAction.insertAdjacentElement('afterend', newElement);
+				}
+			});
+		</script>
+		<?php
+	}
+
+	/**
+	 * Add styles for the CTA
+	 */
+	public function add_style() {
+		?>
+		<style>
+			.nfd-wba-cta-edit-screen {
+				display: inline-flex;
+			}
+			.nfd-wba-cta-edit-screen .page-title-action {
+				align-items: center;
+				border-color: #3d7e29;
+				background-color: #3d7e29;
+				color: #ffffff;
+			}
+			.nfd-wba-cta-edit-screen .page-title-action:hover,
+			.nfd-wba-cta-edit-screen .page-title-action:active {
+				border-color: #3F8F3C;
+				background-color: #3F8F3C;
+				color: #ffffff;
+			}
+			.nfd-wba-cta-edit-screen .page-title-action:focus {
+				border-color: #2f621f;
+				background-color: #2f621f;
+				box-shadow: 0 0 0 1px #2f621f;
+			}
+
+			.nfd-wba-cta-edit-screen svg {
+				margin-right: 5px;
+				position: relative;
+				top: 4px;
+			}
 			@media only screen and (max-width: 433px) {
 				.nfd-wba-cta-edit-screen {
 					margin-top: 6px;
 				}
 			}
-        </style>
-        <?php
-    }
+		</style>
+		<?php
+	}
 
-    /**
-     * Check if we're on the edit pages screen
-     */
-    private function is_core_post_type() {
-        if (!is_admin() || !is_user_logged_in()) {
-            return false;
-        }
+	/**
+	 * Check if we're on the edit pages screen
+	 */
+	private function is_core_post_type() {
+		if ( ! \is_admin() || ! \is_user_logged_in() ) {
+			return false;
+		}
 
-        global $pagenow, $typenow;
-        
-        $is_core_post_type = ('edit.php' === $pagenow && (
-            // Default post type (no post_type parameter)
-            (!isset($_GET['post_type']) && empty($typenow)) ||
-            // Explicit post type check
-            (isset($_GET['post_type']) && in_array($_GET['post_type'], array('post', 'page'), true)) ||
-            // Fallback to typenow
-            in_array($typenow, array('post', 'page'), true)
-        ));
-        
-        return $is_core_post_type;
-    }
+		global $pagenow, $typenow;
+
+		$is_core_post_type = ( 'edit.php' === $pagenow && (
+			// Default post type (no post_type parameter)
+			( ! isset( $_GET['post_type'] ) && empty( $typenow ) ) ||
+			// Explicit post type check
+			( isset( $_GET['post_type'] ) && in_array( $_GET['post_type'], array( 'post', 'page' ), true ) ) ||
+			// Fallback to typenow
+			in_array( $typenow, array( 'post', 'page' ), true )
+		) );
+
+		return $is_core_post_type;
+	}
 }

--- a/includes/Admin/CTA.php
+++ b/includes/Admin/CTA.php
@@ -181,7 +181,7 @@ class CTA {
             $url = admin_url('post-new.php?wb-library=patterns');
         }
 
-        $svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="2.25 6 19.5 13.5" width="18px" height="20px"><path stroke-linecap="round" stroke-linejoin="round" d="M3.34 7.754c0-.552.447-.999.999-.999h5.328a1 1 0 0 1 .999.999v3.329a1 1 0 0 1-.999.999H4.339a.999.999 0 0 1-.999-.999V7.754Zm10.655 1.331a1 1 0 0 1 .999-.998h4.662c.552 0 .999.447.999.998v7.326a.999.999 0 0 1-.999.999h-4.662a1 1 0 0 1-.999-.999V9.085Zm-9.323 6.66a1 1 0 0 1 .998-.999h4.662a1 1 0 0 1 .999.999v1.998a1 1 0 0 1-.999.999H5.67a1 1 0 0 1-.998-.999v-1.998Z" style="fill:none;stroke-width:1.5px;paint-order:stroke;stroke:currentColor"/></svg>';
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="2.25 6 19.5 13.5" width="19px" height="19px"><path stroke-linecap="round" stroke-linejoin="round" d="M3.34 7.754c0-.552.447-.999.999-.999h5.328a1 1 0 0 1 .999.999v3.329a1 1 0 0 1-.999.999H4.339a.999.999 0 0 1-.999-.999V7.754Zm10.655 1.331a1 1 0 0 1 .999-.998h4.662c.552 0 .999.447.999.998v7.326a.999.999 0 0 1-.999.999h-4.662a1 1 0 0 1-.999-.999V9.085Zm-9.323 6.66a1 1 0 0 1 .998-.999h4.662a1 1 0 0 1 .999.999v1.998a1 1 0 0 1-.999.999H5.67a1 1 0 0 1-.998-.999v-1.998Z" style="fill:none;stroke-width:1.5px;paint-order:stroke;stroke:currentColor"/></svg>';
 
         $cta_text = sprintf(
             __('%1$sAdd With WonderBlocks%2$s', 'nfd-wonder-blocks'),
@@ -232,6 +232,11 @@ class CTA {
                 position: relative;
                 top: 4px;
             }
+			@media only screen and (max-width: 433px) {
+				.nfd-wba-cta-edit-screen {
+					margin-top: 6px;
+				}
+			}
         </style>
         <?php
     }


### PR DESCRIPTION
## Proposed changes

* Adds WonderBlocks button in lieu of long sentance
* Adds button to Post screen as well
* Adds ability to show and hide button independently on both screens without deactivating WonderBlocks entirely or requiring custom CSS to hide it
* Matches URLs from launchpads

#### NOTE

Did my best to first tie-in with the `Apply` button and screen options but hit a few roadblocks. Feel free to adjust if you can get it, but this should be secure and functional.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

https://github.com/user-attachments/assets/c9295f2f-5e1c-44e0-bf80-4382f141f66f