### PR TITLE
Enforce modal sidebar toggle group background with new core component styles

### DIFF
--- a/src/styles/modal/modal.scss
+++ b/src/styles/modal/modal.scss
@@ -92,6 +92,9 @@
 
 		.components-toggle-group-control {
 			border-color: var(--nfd-wba-color-borders);
+			&:before {
+				background-color: var(--nfd-wba-color-borders);
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Proposed changes

New component styles introduced for the Toggle Group component in Gutenberg 19.8 and coming in the next major WordPress release in Spring 2025 break the usage in WonderBlocks library modal.

This presents today with customers who have the Gutenberg plugin active.

## Without fix today with Gutenberg active

![CleanShot 2024-12-04 at 14 49 42@2x](https://github.com/user-attachments/assets/48e64f79-c4c7-416c-a38e-295549a5d185)

## With this fix

![CleanShot 2024-12-04 at 14 49 09@2x](https://github.com/user-attachments/assets/2a0bd48a-18f1-4592-90be-c9279a91f9c9)

## Ticket

https://jira.newfold.com/browse/PRESS8-158
