### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -12,15 +12,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   translate:
     name: 'Check and update translations'
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
+    permissions:
+      contents: write      # Required for reusable translation jobs that push branches and commits via GITHUB_TOKEN.
+      pull-requests: write # Required for reusable translation jobs that create or update pull requests with `gh`.
     with:
       text_domain: 'nfd-wonder-blocks'
     secrets:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: write      # Required for reusable translation jobs that push branches and commits via GITHUB_TOKEN.
       pull-requests: write # Required for reusable translation jobs that create or update pull requests with `gh`.
+    timeout-minutes: 120
     with:
       text_domain: 'nfd-wonder-blocks'
     secrets:

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,8 +6,9 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
@@ -17,6 +18,7 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
+    permissions: {} # Uses only git ref env vars; no checkout or GitHub API usage.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -30,6 +32,8 @@ jobs:
     name: Bluehost Build and Test Playwright
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for the reusable workflow to clone private plugin and module repositories.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -19,6 +19,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {} # Uses only git ref env vars; no checkout or GitHub API usage.
+    timeout-minutes: 10
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to clone private plugin and module repositories.
+    timeout-minutes: 60
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,6 +21,7 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {} # No checkout or GitHub API calls; only derives outputs from built-in github context.
+    timeout-minutes: 5
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     permissions:
       contents: write      # Required for the reusable workflow to clone the private repo and push coverage HTML to gh-pages.
       pull-requests: write # Required for the reusable workflow to post or update the coverage comment on pull requests.
+    timeout-minutes: 60
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,12 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {} # No checkout or GitHub API calls; only derives outputs from built-in github context.
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -28,10 +30,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
+    permissions:
+      contents: write      # Required for the reusable workflow to clone the private repo and push coverage HTML to gh-pages.
+      pull-requests: write # Required for the reusable workflow to post or update the coverage comment on pull requests.
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -8,13 +8,15 @@ on:
         required: false
         default: 'main'
 
-permissions:
-  contents: write
-  pull-requests: write
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   call-crowdin-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
+    permissions:
+      contents: read # Required for the reusable Crowdin download job to checkout the private caller repository; Crowdin PR creation uses NEWFOLD_ACCESS_TOKEN (PAT), not GITHUB_TOKEN.
     with:
       base_branch: ${{ inputs.base_branch }}
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -17,6 +17,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
     permissions:
       contents: read # Required for the reusable Crowdin download job to checkout the private caller repository; Crowdin PR creation uses NEWFOLD_ACCESS_TOKEN (PAT), not GITHUB_TOKEN.
+    timeout-minutes: 30
     with:
       base_branch: ${{ inputs.base_branch }}
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -3,9 +3,15 @@ name: Crowdin Upload Action
 on:
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   call-crowdin-upload-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
+    permissions:
+      contents: read # Required for the reusable Crowdin upload job to checkout the private caller repository.
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -12,6 +12,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     permissions:
       contents: read # Required for the reusable Crowdin upload job to checkout the private caller repository.
+    timeout-minutes: 30
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # Required for actions/checkout to clone the private repository.
+      pull-requests: read  # Required for technote-space/get-diff-action to resolve the pull request diff on pull_request events.
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: read       # Required for actions/checkout to clone the private repository.
       pull-requests: read  # Required for technote-space/get-diff-action to resolve the pull request diff on pull_request events.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       contents: write      # Required for the reusable workflow to push the release branch and version bumps.
       pull-requests: write # Required for the reusable workflow to open the release pull request.
+    timeout-minutes: 45
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -20,10 +20,10 @@ jobs:
   # This job runs the newfold module-prep-release workflow for this module.
   prep-release:
     name: Prepare Release
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
+    permissions:
+      contents: write      # Required for the reusable workflow to push the release branch and version bumps.
+      pull-requests: write # Required for the reusable workflow to open the release pull request.
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # Repository dispatch uses secrets.WEBHOOK_TOKEN only; GITHUB_TOKEN is not used against the GitHub API.
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -14,6 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {} # Repository dispatch uses secrets.WEBHOOK_TOKEN only; GITHUB_TOKEN is not used against the GitHub API.
+    timeout-minutes: 30
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 8 (`auto-translate.yml`, `brand-plugin-test-playwright.yml`, `codecoverage-main.yml`, `i18n-crowdin-download.yml`, `i18n-crowdin-upload.yml`, `lint.yml`, `newfold-prep-release.yml`, `satis-update.yml`) |
| Verification | glob `**/wp-module-patterns/.github/workflows/*.yml` — 8 YAML files matched; zero `*.yaml` files in `.github/workflows` |
| Branch | `add/scoped-workflow-permissions` not created — no remediation applied (audit-only; no edits) |
| Permissions commit | none |
| Timeouts commit | none |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | *Not applicable — no changes committed.* The following workflows are **non-compliant** with the required `# Disable permissions …` comment pair immediately followed by `permissions: {}` immediately before `jobs:` (some have no equivalent block; others place non-empty workflow `permissions:` or omit the mandated comments): |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-update.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `codecoverage-main.yml` (workflow-level `contents: read` instead of `{}` + mandated comments before `jobs:`) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `brand-plugin-test-playwright.yml` (workflow-level `contents: read`; comments/`{}` pattern missing) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `i18n-crowdin-upload.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `i18n-crowdin-download.yml` (workflow-level `contents: write` / `pull-requests: write` instead of `{}` + mandated comments) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `auto-translate.yml` (`permissions: {}` present but **without** the two mandated comment lines before it) |
| Compliant with the **required** top-level pattern: `newfold-prep-release.yml` | — |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| *Not applicable — no changes committed.* Jobs that **lack** a `permissions:` block immediately after `runs-on:` / `uses:` (or need tightening to least privilege with per-permission trailing comments as required by the audit policy): | — | — | `satis-update.yml`: 1 job — `webhook`<br>Likely `permissions: {}` for the default `GITHUB_TOKEN` [3] — uses `peter-evans/repository-dispatch` with `secrets.WEBHOOK_TOKEN` (not `github.token`); no `actions/checkout` step.<br>`lint.yml`: 1 job — `phpcs`<br>Add `contents: read` [3] — `actions/checkout` needs clone access in a private repo.<br>`codecoverage-main.yml`: 1 job — `get-repo-name`<br>Add explicit `permissions: {}` [3] — no checkout / no GitHub API use in shown steps.<br>`codecoverage-main.yml`: job `codecoverage` already declares `contents: write` and `pull-requests: write` but **without** the required trailing inline comment on each key (should be brought in line with the audit’s “comment per permission” rule).<br>`brand-plugin-test-playwright.yml`: 2 jobs — `setup`, `bluehost`<br>`setup`: likely `permissions: {}` [3] — branch name echo only.<br>`bluehost`: at minimum `contents: read` for typical reusable clone patterns [2] — exact needs depend on `newfold-labs/workflows` `module-plugin-test-playwright.yml@main` (not fully verified from this repo).<br>`i18n-crowdin-upload.yml`: 1 job — `call-crowdin-upload-workflow`<br>Missing job `permissions:` entirely [2] — scope should be derived from `newfold-labs/workflows` `i18n-crowdin-upload.yml@main` (Crowdin + any PR/push behavior).<br>`i18n-crowdin-download.yml`: 1 job — `call-crowdin-workflow`<br>Move workflow-level `contents: write` / `pull-requests: write` to **this** job and add per-permission trailing comments [2] — behavior depends on reusable workflow (not fully verified from this repo).<br>`auto-translate.yml`: job `translate` already has write scopes but **without** per-permission trailing comments (should be aligned with the audit format). |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `codecoverage-main.yml` :: workflow: BEFORE `permissions: contents: read` (top-level) -> AFTER top-level `permissions: {}` plus job-scoped permissions (with `get-repo-name` explicit `contents: read` only if later steps add checkout/API use) — reason: audit requires default-deny at workflow level and least privilege on jobs — [3] |
| 2 | `brand-plugin-test-playwright.yml` :: workflow: BEFORE `permissions: contents: read` (top-level) -> AFTER top-level `permissions: {}` plus job-level scoped permissions — reason: same — [3] |
| 3 | `i18n-crowdin-download.yml` :: workflow: BEFORE `contents: write` + `pull-requests: write` at workflow level -> AFTER top-level `permissions: {}` and the same scopes on the job that calls the reusable workflow (with inline comments) — reason: workflow-wide elevation violates the audit’s default-deny pattern — [3] |
| 4 | `auto-translate.yml` :: workflow: BEFORE `permissions: {}` without mandated comment block -> AFTER two-line comment block + `permissions: {}` before `jobs:` — reason: audit mandates the exact preamble — [3] |
| 5 | `newfold-prep-release.yml` :: `prep-release`: BEFORE `contents: write` / `pull-requests: write` without per-line comments -> AFTER same keys with trailing comments (e.g. push branch, open PR) — reason: matches audit’s required comment style — [2] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| — | — | — | No job in any workflow currently sets `timeout-minutes` (repo-wide grep in `.github/workflows`: no matches). **Suggested** additions (not applied; pick values to match expected runtime — often 30 minutes): |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | Permissions for jobs that only `uses:` reusable workflows (`newfold-labs/workflows@main`) should be validated against those reusable workflow definitions plus [GitHub workflow `permissions` documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions); this audit infers scopes from naming and typical patterns where the callee was not fetched. |
| 2 | Third-party actions in `lint.yml` (`technote-space/get-diff-action`, `shivammathur/setup-php`, `actions/cache`) were not traced line-by-line for default `GITHUB_TOKEN` usage beyond `actions/checkout` — if any step elevates implicitly, tighten job permissions accordingly after verification. |
| 3 | `satis-update.yml`: `secrets.WEBHOOK_TOKEN` is a PAT/application token to another repo; rotate/review secrecy separately from `GITHUB_TOKEN` hardening — still apply default workflow `permissions: {}` + explicit job scopes for completeness. |
| 4 | [REDACTED] |


