### PR TITLE
Adopt wp-php-standards 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "newfold-labs/wp-module-installer": "^1.7"
     },
     "require-dev": {
-        "newfold-labs/wp-php-standards": "^2.0.0",
+        "newfold-labs/wp-php-standards": "^2.0",
         "wp-cli/i18n-command": "^2.7.0",
         "johnpbloch/wordpress": "@stable",
         "lucatume/wp-browser": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d89d048afc88cec7cb526bdfaf47dd72",
+    "content-hash": "de251d33b9c6318cd0a1e6d512c1834a",
     "packages": [
         {
             "name": "doctrine/inflector",


### PR DESCRIPTION
Updates the PHP standards dependency to ^2.0.